### PR TITLE
Port to Agda 2.8, bug fixes, and interface improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,12 +49,9 @@ $ agda-unused Test.agda
 Output:
 
 ```
-/home/user/Test.agda:4.23-27
-  unused imported item ‘true’
-/home/user/Test.agda:5.1-30
-  unused import ‘Agda.Builtin.Unit’
-/home/user/Test.agda:11.9-10
-  unused variable ‘x’
+Test.agda:4.23-27: unused imported item ‘true’
+Test.agda:5.1-30: unused import ‘Agda.Builtin.Unit’
+Test.agda:11.9-10: unused variable ‘x’
 ```
 
 ## Usage
@@ -62,19 +59,56 @@ Output:
 ```
 agda-unused - check for unused code in an Agda project
 
-Usage: agda-unused FILE [-g|--global] [-j|--json]
-  Check for unused code in FILE
+Usage: agda-unused [FILE] [(-g|--global) | --local]
+                   [(--only CATEGORY) | (--all-but CATEGORY) | --all]
+                   [-j|--json] [--config FILE | --no-config]
+
+  Check for unused code in FILE (or use 'file' from config)
 
 Available options:
   -h,--help                Show this help text
-  -g,--global              Check project globally
-  -j,--json                Format output as JSON
+  -g,--global              Treat FILE as the project's complete public interface
+  --local                  Only report private unused code (default)
+  --only CATEGORY          Only report these categories (repeatable)
+  --all-but CATEGORY       Report all categories but these (repeatable)
+  --all                    Report all categories (override config filter)
   -i,--include-path DIR    Look for imports in DIR
   -l,--library LIB         Use library LIB
   --library-file FILE      Use FILE instead of the standard libraries file
   --no-libraries           Don't use any library files
   --no-default-libraries   Don't use default libraries
+  -j,--json                Format output as JSON
+  --config FILE            Use this config file instead of auto-discovery
+  --no-config              Don't load any config file
+
+Categories: data, definitions, imports, import-items, modules, module-items,
+opens, open-items, pattern-synonyms, postulates, records, record-constructors,
+variables, mutual
 ```
+
+## Configuration
+
+`agda-unused` looks for a `.agda-unused.yaml` configuration file starting from
+the checked file's directory and searching upward. Use `--config FILE` to
+specify one explicitly, or `--no-config` to skip config loading.
+
+Example `.agda-unused.yaml`:
+
+```yaml
+file: Everything.agda  # default file when no FILE argument
+global: true           # equivalent to --global
+all-but:               # mutually exclusive with 'only'
+  - variables
+```
+
+Agda library options can also be set in the config: `include` (list of
+include paths), `libraries` (list of library names), `library-file` (override
+`~/.agda/libraries`), `use-libraries` and `use-default-libraries` (booleans,
+both default to `true`). These are rarely needed since Agda resolves libraries
+from `.agda-lib` files automatically.
+
+CLI flags take precedence over config file settings. For list fields
+(`include`, `libraries`), CLI values replace (not append) config values.
 
 ## Global
 
@@ -87,10 +121,10 @@ check for unused files.
 To perform a global check on an Agda project, first create a file that imports
 exactly the intended public interface of your project. For example:
 
-File `All.agda`:
+File `Everything.agda`:
 
 ```
-module All where
+module Everything where
 
 import A
   using (f)
@@ -102,7 +136,7 @@ import C
 Command:
 
 ```
-$ agda-unused All.agda --global
+$ agda-unused Everything.agda --global
 ```
 
 ## JSON

--- a/README.md
+++ b/README.md
@@ -181,3 +181,6 @@ Additionally, we currently do not support the following Agda features:
 
 `agda-unused` will produce an error if your code uses these language features.
 
+When `open import M as N` or `open module N = M` is used, qualified access
+(`N.foo`) and unqualified access (`foo`) are tracked together.  This means that
+if only qualified access is used, the redundant `open` is not reported.

--- a/README.md
+++ b/README.md
@@ -176,7 +176,6 @@ drawbacks:
 
 Additionally, we currently do not support the following Agda features:
 
-- [record module instance applications](https://agda.readthedocs.io/en/v2.8.0/language/module-system.html#parameterised-modules)
 - [unquoting declarations](https://agda.readthedocs.io/en/v2.8.0/language/reflection.html#id3)
 - [lone constructors](https://agda.readthedocs.io/en/v2.8.0/language/mutual-recursion.html#interleaved-mutual-blocks)
 

--- a/README.md
+++ b/README.md
@@ -181,6 +181,9 @@ Additionally, we currently do not support the following Agda features:
 
 `agda-unused` will produce an error if your code uses these language features.
 
+Instance declarations are always treated as used, since determining which
+instances are selected requires type-checking.
+
 When `open import M as N` or `open module N = M` is used, qualified access
 (`N.foo`) and unqualified access (`foo`) are tracked together.  This means that
 if only qualified access is used, the redundant `open` is not reported.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ flag, `agda-unused` treats the given file as a description of the public
 interface of the project, and additionally checks for unused files and unused
 public items in dependencies. (See below for more on `--global`.)
 
-Supported Agda versions: `>= 2.6.3 && < 2.6.4`
+Supported Agda versions: `>= 2.8.0 && < 2.8.1`
 
 ## Example
 
@@ -49,11 +49,11 @@ $ agda-unused Test.agda
 Output:
 
 ```
-/home/user/Test.agda:4,23-27
+/home/user/Test.agda:4.23-27
   unused imported item ‘true’
-/home/user/Test.agda:5,1-30
+/home/user/Test.agda:5.1-30
   unused import ‘Agda.Builtin.Unit’
-/home/user/Test.agda:11,9-10
+/home/user/Test.agda:11.9-10
   unused variable ‘x’
 ```
 
@@ -142,9 +142,9 @@ drawbacks:
 
 Additionally, we currently do not support the following Agda features:
 
-- [record module instance applications](https://agda.readthedocs.io/en/v2.6.2/language/module-system.html#parameterised-modules)
-- [unquoting declarations](https://agda.readthedocs.io/en/v2.6.2/language/reflection.html#id3)
-- [lone constructors](https://agda.readthedocs.io/en/v2.6.2/language/mutual-recursion.html#interleaved-mutual-blocks)
+- [record module instance applications](https://agda.readthedocs.io/en/v2.8.0/language/module-system.html#parameterised-modules)
+- [unquoting declarations](https://agda.readthedocs.io/en/v2.8.0/language/reflection.html#id3)
+- [lone constructors](https://agda.readthedocs.io/en/v2.8.0/language/mutual-recursion.html#interleaved-mutual-blocks)
 
 `agda-unused` will produce an error if your code uses these language features.
 

--- a/README.md
+++ b/README.md
@@ -182,8 +182,35 @@ Additionally, we currently do not support the following Agda features:
 `agda-unused` will produce an error if your code uses these language features.
 
 Instance declarations are always treated as used, since determining which
-instances are selected requires type-checking.
+instances are selected requires type-checking.  Imports that only provide
+instances can be suppressed with `-- agda-unused: instances` (see below).
 
 When `open import M as N` or `open module N = M` is used, qualified access
 (`N.foo`) and unqualified access (`foo`) are tracked together.  This means that
 if only qualified access is used, the redundant `open` is not reported.
+
+## Suppression Comments
+
+You can suppress specific reports with inline comments:
+
+- `-- agda-unused: ignore` — suppress all reports on the same line
+- `-- agda-unused: instances` — suppress whole-import reports on the same line
+  (useful for imports that provide instances)
+
+Examples:
+
+```agda
+-- Suppress a report for a definition used only via a REWRITE pragma,
+-- which agda-unused doesn't track:
++-assoc : ...       -- agda-unused: ignore
+{-# REWRITE +-assoc #-}
+
+-- Keep the import (it provides instances used implicitly by the type
+-- checker):
+import Data.Nat.Properties  -- agda-unused: instances
+```
+
+The `instances` marker only suppresses the whole-import report. If the import
+has a `using` list with individually unused items, those are still reported.
+This is useful since `agda-unused` does not perform type checking and cannot
+determine whether instances from an import are actually used.

--- a/agda-unused.cabal
+++ b/agda-unused.cabal
@@ -46,13 +46,13 @@ library
     Agda.Unused.Types.Range
     Agda.Unused.Utils
   build-depends:
-    base >= 4.13 && < 4.19,
-    Agda >= 2.6.3 && < 2.6.4,
-    containers >= 0.6.2 && < 0.7,
+    base >= 4.13 && < 5,
+    Agda >= 2.8.0 && < 2.8.1,
+    containers >= 0.6.2 && < 0.8,
     directory >= 1.3.6 && < 1.4,
-    filepath >= 1.4.2 && < 1.5,
+    filepath >= 1.4.2 && < 1.6,
     mtl >= 2.2.2 && < 2.4,
-    text >= 1.2.4 && < 2.1
+    text >= 1.2.4 && < 2.2
   default-language:
     Haskell2010
   default-extensions:
@@ -71,12 +71,12 @@ executable agda-unused
     Main.hs
   build-depends:
     agda-unused,
-    base >= 4.13 && < 4.19,
-    aeson >= 2 && < 2.3,
+    base >= 4.13 && < 5,
+    aeson >= 2 && < 2.4,
     directory >= 1.3.6 && < 1.4,
     mtl >= 2.2.2 && < 2.4,
     optparse-applicative >= 0.15.1 && < 0.19,
-    text >= 1.2.4 && < 2.1
+    text >= 1.2.4 && < 2.2
   default-language:
     Haskell2010
   default-extensions:
@@ -99,11 +99,11 @@ test-suite test
     Paths_agda_unused
   build-depends:
     agda-unused,
-    base >= 4.13 && < 4.19,
-    containers >= 0.6.2 && < 0.7,
-    filepath >= 1.4.2 && < 1.5,
+    base >= 4.13 && < 5,
+    containers >= 0.6.2 && < 0.8,
+    filepath >= 1.4.2 && < 1.6,
     hspec >= 2.7.1 && < 2.12,
-    text >= 1.2.4 && < 2.1
+    text >= 1.2.4 && < 2.2
   default-language:
     Haskell2010
   default-extensions:
@@ -111,4 +111,3 @@ test-suite test
     OverloadedStrings
   ghc-options:
     -Wall
-

--- a/agda-unused.cabal
+++ b/agda-unused.cabal
@@ -54,6 +54,7 @@ library
     Agda.Unused.Monad.Reader
     Agda.Unused.Monad.State
     Agda.Unused.Print
+    Agda.Unused.Suppress
     Agda.Unused.Types.Access
     Agda.Unused.Types.Context
     Agda.Unused.Types.Name

--- a/agda-unused.cabal
+++ b/agda-unused.cabal
@@ -30,7 +30,21 @@ source-repository head
   location:
     https://github.com/msuperdock/agda-unused.git
 
+common shared
+  build-depends:
+    base >= 4.13 && < 5,
+    filepath >= 1.4.2 && < 1.6,
+    text >= 1.2.4 && < 2.2
+  default-language:
+    Haskell2010
+  default-extensions:
+    GADTs,
+    OverloadedStrings
+  ghc-options:
+    -Wall
+
 library
+  import: shared
   hs-source-dirs:
     src
   exposed-modules:
@@ -46,47 +60,38 @@ library
     Agda.Unused.Types.Range
     Agda.Unused.Utils
   build-depends:
-    base >= 4.13 && < 5,
     Agda >= 2.8.0 && < 2.8.1,
+    aeson >= 2 && < 2.4,
     containers >= 0.6.2 && < 0.8,
     directory >= 1.3.6 && < 1.4,
-    filepath >= 1.4.2 && < 1.6,
-    mtl >= 2.2.2 && < 2.4,
-    text >= 1.2.4 && < 2.2
-  default-language:
-    Haskell2010
+    mtl >= 2.2.2 && < 2.4
   default-extensions:
     FlexibleContexts,
-    FlexibleInstances,
-    GADTs,
-    OverloadedStrings
+    FlexibleInstances
   ghc-options:
-    -Wall
     -Wno-orphans
 
 executable agda-unused
+  import: shared
   hs-source-dirs:
     app
   main-is:
     Main.hs
+  other-modules:
+    Config
   build-depends:
     agda-unused,
-    base >= 4.13 && < 5,
     aeson >= 2 && < 2.4,
+    bytestring >= 0.10 && < 0.13,
     directory >= 1.3.6 && < 1.4,
     mtl >= 2.2.2 && < 2.4,
     optparse-applicative >= 0.15.1 && < 0.19,
-    text >= 1.2.4 && < 2.2
-  default-language:
-    Haskell2010
+    yaml >= 0.11 && < 0.12
   default-extensions:
-    FlexibleContexts,
-    GADTs,
-    OverloadedStrings
-  ghc-options:
-    -Wall
+    FlexibleContexts
 
 test-suite test
+  import: shared
   type:
     exitcode-stdio-1.0
   hs-source-dirs:
@@ -99,15 +104,5 @@ test-suite test
     Paths_agda_unused
   build-depends:
     agda-unused,
-    base >= 4.13 && < 5,
     containers >= 0.6.2 && < 0.8,
-    filepath >= 1.4.2 && < 1.6,
-    hspec >= 2.7.1 && < 2.12,
-    text >= 1.2.4 && < 2.2
-  default-language:
-    Haskell2010
-  default-extensions:
-    GADTs,
-    OverloadedStrings
-  ghc-options:
-    -Wall
+    hspec >= 2.7.1 && < 2.12

--- a/app/Config.hs
+++ b/app/Config.hs
@@ -1,0 +1,212 @@
+{- |
+Module: Config
+
+Per-project configuration file support for agda-unused.
+
+Discovers and parses @.agda-unused.yaml@ files by walking up from
+the target file's directory toward the filesystem root.
+-}
+module Config
+  ( Category(..)
+  , CategoryFilter(..)
+  , Config(..)
+  , categoryLabel
+  , categoryOf
+  , defaultConfig
+  , findConfigFile
+  , loadConfig
+  , allCategoryLabels
+  , filterUnusedItems
+  , filterUnused
+  , parseCategory
+  ) where
+
+import Agda.Unused
+  (Unused(..), UnusedItems(..))
+import Agda.Unused.Types.Range
+  (RangeInfo(..), RangeType(..), parseRangeType, rangeTypeLabel,
+    allRangeTypes)
+
+import Data.Aeson
+  (FromJSON(..), (.:?), (.!=), withObject)
+import qualified Data.ByteString
+  as BS
+import Data.List
+  (intercalate)
+import Data.Text
+  (Text)
+import qualified Data.Text
+  as T
+import Data.Yaml
+  (decodeEither')
+import System.Directory
+  (doesFileExist)
+import System.FilePath
+  ((</>), takeDirectory)
+
+-- ## Types
+
+-- | A report category, including the special "mutual" category which
+-- is not a 'RangeType'.
+data Category
+  = Category !RangeType
+  | CategoryMutual
+  deriving (Eq, Ord, Show)
+
+-- | Category filter: either an inclusion list or exclusion list.
+data CategoryFilter
+  = Only [Category]
+  | AllBut [Category]
+  deriving Show
+
+-- | Per-project configuration.
+data Config
+  = Config
+  { configFile
+    :: !(Maybe FilePath)
+    -- ^ Default file to check (used when no FILE argument given).
+  , configGlobal
+    :: !(Maybe Bool)
+    -- ^ Whether to check in global mode. 'Nothing' means unspecified.
+  , configFilter
+    :: !(Maybe CategoryFilter)
+    -- ^ Category filter. 'Nothing' means unspecified (report all).
+  , configInclude
+    :: ![FilePath]
+    -- ^ Include paths for Agda.
+  , configLibraries
+    :: ![Text]
+    -- ^ Libraries for Agda.
+  , configLibraryFile
+    :: !(Maybe FilePath)
+    -- ^ Alternate libraries file for Agda.
+  , configUseLibraries
+    :: !(Maybe Bool)
+    -- ^ Whether to use library files. 'Nothing' means unspecified.
+  , configUseDefaultLibraries
+    :: !(Maybe Bool)
+    -- ^ Whether to use default libraries. 'Nothing' means unspecified.
+  } deriving Show
+
+-- | Default configuration: everything unspecified.
+defaultConfig :: Config
+defaultConfig
+  = Config
+  { configFile = Nothing
+  , configGlobal = Nothing
+  , configFilter = Nothing
+  , configInclude = []
+  , configLibraries = []
+  , configLibraryFile = Nothing
+  , configUseLibraries = Nothing
+  , configUseDefaultLibraries = Nothing
+  }
+
+-- ## Category
+
+-- | Parse a single category label.
+parseCategory :: String -> Either String Category
+parseCategory "mutual"
+  = Right CategoryMutual
+parseCategory s
+  = case parseRangeType s of
+    Just rt -> Right (Category rt)
+    Nothing -> Left ("Unknown category: " ++ s
+      ++ ". Valid: " ++ allCategoryLabels)
+
+-- | The label for a category.
+categoryLabel :: Category -> String
+categoryLabel CategoryMutual = "mutual"
+categoryLabel (Category rt) = rangeTypeLabel rt
+
+-- | Comma-separated list of all valid category labels, for help text.
+allCategoryLabels :: String
+allCategoryLabels
+  = intercalate ", " (map rangeTypeLabel allRangeTypes ++ ["mutual"])
+
+-- | Determine the category of a range info.
+categoryOf :: RangeInfo -> Category
+categoryOf (RangeNamed rt _) = Category rt
+categoryOf RangeMutual = CategoryMutual
+
+-- ## YAML Parsing
+
+instance FromJSON Config where
+  parseJSON = withObject "Config" $ \o -> do
+    rootFile <- o .:? "file"
+    globalMode <- o .:? "global"
+    onlyLabels <- o .:? "only" .!= ([] :: [Text])
+    allButLabels <- o .:? "all-but" .!= ([] :: [Text])
+    if not (null onlyLabels) && not (null allButLabels)
+      then fail "Config error: 'only' and 'all-but' are mutually exclusive."
+      else pure ()
+    filt <- if not (null onlyLabels)
+      then case traverse (parseCategory . T.unpack) onlyLabels of
+        Left err -> fail err
+        Right cs -> pure (Just (Only cs))
+      else if not (null allButLabels)
+      then case traverse (parseCategory . T.unpack) allButLabels of
+        Left err -> fail err
+        Right cs -> pure (Just (AllBut cs))
+      else pure Nothing
+    includePaths <- o .:? "include" .!= ([] :: [Text])
+    libraries <- o .:? "libraries" .!= ([] :: [Text])
+    libraryFile <- o .:? "library-file"
+    useLibraries <- o .:? "use-libraries"
+    useDefaultLibraries <- o .:? "use-default-libraries"
+    pure Config
+      { configFile = T.unpack <$> rootFile
+      , configGlobal = globalMode
+      , configFilter = filt
+      , configInclude = map T.unpack includePaths
+      , configLibraries = libraries
+      , configLibraryFile = T.unpack <$> libraryFile
+      , configUseLibraries = useLibraries
+      , configUseDefaultLibraries = useDefaultLibraries
+      }
+
+-- ## Discovery
+
+configFileName :: String
+configFileName = ".agda-unused.yaml"
+
+-- | Walk up from the given directory looking for
+-- @.agda-unused.yaml@. Returns the first one found, or 'Nothing'.
+findConfigFile :: FilePath -> IO (Maybe FilePath)
+findConfigFile dir = do
+  let candidate = dir </> configFileName
+  exists <- doesFileExist candidate
+  if exists
+    then pure (Just candidate)
+    else let parent = takeDirectory dir
+         in if parent == dir
+            then pure Nothing
+            else findConfigFile parent
+
+-- | Load and parse a config file.
+loadConfig :: FilePath -> IO (Either String Config)
+loadConfig path = do
+  bs <- BS.readFile path
+  pure $ case decodeEither' bs of
+    Left err -> Left (show err)
+    Right cfg -> Right cfg
+
+-- ## Filtering
+
+-- | Filter unused items according to a category filter.
+filterUnusedItems :: Maybe CategoryFilter -> UnusedItems -> UnusedItems
+filterUnusedItems Nothing items
+  = items
+filterUnusedItems (Just filt) (UnusedItems items)
+  = UnusedItems (filter (keepItem filt . snd) items)
+
+-- | Filter unused items and files according to a category filter.
+filterUnused :: Maybe CategoryFilter -> Unused -> Unused
+filterUnused filt (Unused files items)
+  = Unused files (filterUnusedItems filt items)
+
+keepItem :: CategoryFilter -> RangeInfo -> Bool
+keepItem (Only cats) ri
+  = categoryOf ri `elem` cats
+keepItem (AllBut cats) ri
+  = categoryOf ri `notElem` cats

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -7,7 +7,12 @@ import Agda.Unused.Check
 import Agda.Unused.Monad.Error
   (Error)
 import Agda.Unused.Print
-  (printError, printNothing, printUnused, printUnusedItems)
+  (printError, printNothing, printUnused, printUnusedItems,
+    relativizeUnused, relativizeUnusedItems)
+import Config
+  (CategoryFilter(..), Config(..), allCategoryLabels, defaultConfig,
+    filterUnused, filterUnusedItems, findConfigFile, loadConfig,
+    parseCategory)
 
 import Control.Monad
   (unless)
@@ -28,103 +33,78 @@ import qualified Data.Text.IO
 import Data.Text.Lazy
   (toStrict)
 import Options.Applicative
-  (InfoMod, Parser, ParserInfo, execParser, fullDesc, header, help, helper,
-    hidden, info, long, many, metavar, optional, progDesc, short, strArgument,
-    strOption, switch)
+  (InfoMod, Parser, ParserInfo, eitherReader, execParser, flag', footer,
+    fullDesc, header, help, helper, hidden, info, long, many, metavar, option,
+    optional, progDesc, short, some, strArgument, strOption, switch, (<|>))
 import System.Directory
-  (doesDirectoryExist, doesFileExist, makeAbsolute)
+  (doesDirectoryExist, doesFileExist, getCurrentDirectory, makeAbsolute)
+import System.FilePath
+  ((</>), takeDirectory)
 import System.Exit
   (exitFailure, exitSuccess)
 import System.IO
-  (stderr)
+  (hPutStrLn, stderr)
 
 -- ## Options
 
+data ConfigMode
+  = ConfigAuto
+  | ConfigFile !FilePath
+  | ConfigNone
+  deriving Show
+
 data Options
   = Options
-  { optionsFile
-    :: !FilePath
-    -- ^ Path of the file to check.
-  , optionsGlobal
-    :: !Bool
-    -- ^ Whether to check project globally.
+  { optionsConfig
+    :: !Config
+    -- ^ Project-level settings (same type as YAML config).
   , optionsJSON
     :: !Bool
     -- ^ Whether to format output as JSON.
-  , optionsInclude
-    :: ![FilePath]
-    -- ^ Include paths.
-  , optionsLibraries
-    :: ![Text]
-    -- ^ Libraries.
-  , optionsLibrariesFile
-    :: Maybe FilePath
-    -- ^ Alternate libraries file.
-  , optionsNoLibraries
-    :: Bool
-    -- ^ Whether to not use any library files.
-  , optionsNoDefaultLibraries
-    :: Bool
-    -- ^ Whether to not use default libraries.
+  , optionsConfigMode
+    :: !ConfigMode
+    -- ^ How to find the config file.
   } deriving Show
-
--- Convert options; print error message & exit on failure.
-optionsUnused
-  :: Options
-  -> IO (FilePath, UnusedOptions)
-optionsUnused opts
-  = runExceptT (optionsUnused' opts)
-  >>= optionsUnusedEither
-
-optionsUnusedEither
-  :: Either OptionsError (FilePath, UnusedOptions)
-  -> IO (FilePath, UnusedOptions)
-optionsUnusedEither (Left e)
-  = I.hPutStrLn stderr (printOptionsError e) >> exitFailure
-optionsUnusedEither (Right opts)
-  = pure opts
-
-optionsUnused'
-  :: MonadError OptionsError m
-  => MonadIO m
-  => Options
-  -> m (FilePath, UnusedOptions)
-optionsUnused' opts = do
-  filePath
-    <- validateFile (optionsFile opts)
-  includePaths
-    <- traverse validateDirectory (optionsInclude opts)
-  libraryPath
-    <- traverse validateFile (optionsLibrariesFile opts)
-  pure
-    $ (,) filePath
-    $ UnusedOptions
-    { unusedOptionsInclude
-      = includePaths
-    , unusedOptionsLibraries
-      = optionsLibraries opts
-    , unusedOptionsLibrariesFile
-      = libraryPath
-    , unusedOptionsUseLibraries
-      = not (optionsNoLibraries opts)
-    , unusedOptionsUseDefaultLibraries
-      = not (optionsNoDefaultLibraries opts)
-    }
 
 optionsParser
   :: Parser Options
 optionsParser
   = Options
-  <$> (strArgument
-    $ metavar "FILE")
-  <*> (switch
-    $ short 'g'
-    <> long "global"
-    <> help "Check project globally")
+  <$> configParser
   <*> (switch
     $ short 'j'
     <> long "json"
     <> help "Format output as JSON")
+  <*> (ConfigFile <$> strOption
+    (long "config"
+    <> metavar "FILE"
+    <> help "Use this config file instead of auto-discovery")
+    <|> ConfigNone <$ flag' () (long "no-config"
+    <> help "Don't load any config file")
+    <|> pure ConfigAuto)
+
+configParser
+  :: Parser Config
+configParser
+  = Config
+  <$> optional (strArgument
+    $ metavar "FILE")
+  <*> (Just True <$ flag' () (short 'g' <> long "global"
+    <> help "Treat FILE as the project's complete public interface")
+    <|> Just False <$ flag' () (long "local"
+    <> help "Only report private unused code (default)")
+    <|> pure Nothing)
+  <*> (Just . Only <$> some (option categoryReader
+    $ long "only"
+    <> metavar "CATEGORY"
+    <> help "Only report these categories (repeatable)")
+    <|> Just . AllBut <$> some (option categoryReader
+    $ long "all-but"
+    <> metavar "CATEGORY"
+    <> help "Report all categories but these (repeatable)")
+    <|> Just (AllBut []) <$ flag' () (long "all"
+    <> help "Report all categories (override config filter)")
+    <|> pure Nothing)
   <*> many (strOption
     $ short 'i'
     <> long "include-path"
@@ -142,28 +122,61 @@ optionsParser
     <> metavar "FILE"
     <> help "Use FILE instead of the standard libraries file"
     <> hidden)
-  <*> (switch
-    $ long "no-libraries"
+  <*> (Just False <$ flag' () (long "no-libraries"
     <> help "Don't use any library files"
     <> hidden)
-  <*> (switch
-    $ long "no-default-libraries"
+    <|> pure Nothing)
+  <*> (Just False <$ flag' () (long "no-default-libraries"
     <> help "Don't use default libraries"
     <> hidden)
+    <|> pure Nothing)
+  where
+    categoryReader = eitherReader parseCategory
 
 optionsInfo
   :: InfoMod a
 optionsInfo
   = fullDesc
-  <> progDesc "Check for unused code in FILE"
+  <> progDesc "Check for unused code in FILE (or use 'file' from config)"
   <> header "agda-unused - check for unused code in an Agda project"
+  <> footer ("Categories: " ++ allCategoryLabels)
 
 options
   :: ParserInfo Options
 options
   = info (helper <*> optionsParser) optionsInfo
 
--- ## Validate
+-- ## Config resolution
+
+-- | Find and load the YAML config file, if any.
+-- Resolves configFile relative to the config file's directory.
+resolveConfig :: ConfigMode -> FilePath -> IO (Maybe Config)
+resolveConfig ConfigNone _
+  = pure Nothing
+resolveConfig ConfigAuto searchFrom
+  = findConfigFile searchFrom >>= loadConfigPath
+resolveConfig (ConfigFile p) _ = do
+  exists <- doesFileExist p
+  if exists
+    then loadConfigPath (Just p)
+    else hPutStrLn stderr ("Error: Config file not found: " ++ p)
+      >> exitFailure
+
+loadConfigPath :: Maybe FilePath -> IO (Maybe Config)
+loadConfigPath Nothing
+  = pure Nothing
+loadConfigPath (Just path) = do
+  result <- loadConfig path
+  case result of
+    Left err -> do
+      hPutStrLn stderr ("Error loading config: " ++ err)
+      exitFailure
+    Right cfg -> do
+      let dir = takeDirectory path
+          resolved = cfg { configFile = (dir </>) <$> configFile cfg }
+      pure (Just resolved)
+
+-- ## Merge and validate
 
 data OptionsError where
 
@@ -219,20 +232,110 @@ validateDirectory p = do
     <- liftIO (makeAbsolute p)
   pure filePath
 
+-- | Merge CLI config with YAML config, validate paths, and produce
+-- everything needed by the check functions.
+mergeValidateOpts
+  :: Config
+  -- ^ CLI config.
+  -> Maybe Config
+  -- ^ YAML config (with configFile already resolved), if any.
+  -> IO (FilePath, Bool, Maybe CategoryFilter, UnusedOptions)
+mergeValidateOpts cli mYaml
+  = runExceptT (mergeValidateOpts' cli mYaml)
+  >>= mergeValidateEither
+
+mergeValidateEither
+  :: Either OptionsError (FilePath, Bool, Maybe CategoryFilter, UnusedOptions)
+  -> IO (FilePath, Bool, Maybe CategoryFilter, UnusedOptions)
+mergeValidateEither (Left e)
+  = I.hPutStrLn stderr (printOptionsError e) >> exitFailure
+mergeValidateEither (Right result)
+  = pure result
+
+mergeValidateOpts'
+  :: MonadError OptionsError m
+  => MonadIO m
+  => Config
+  -> Maybe Config
+  -> m (FilePath, Bool, Maybe CategoryFilter, UnusedOptions)
+mergeValidateOpts' cli mYaml = do
+  let yaml = maybe defaultConfig id mYaml
+
+  -- Merge: file
+  filePath <- case configFile cli <|> configFile yaml of
+    Just f  -> validateFile f
+    Nothing -> liftIO
+      $ hPutStrLn stderr "Error: No FILE argument and no 'file' in config."
+      >> exitFailure
+
+  -- Merge: other fields
+  let globalMode
+        = maybe False id (configGlobal cli <|> configGlobal yaml)
+      filt
+        = configFilter cli <|> configFilter yaml
+      include
+        = replaceIfNonEmpty (configInclude cli) (configInclude yaml)
+      libraries
+        = replaceIfNonEmpty (configLibraries cli) (configLibraries yaml)
+      libraryFile
+        = configLibraryFile cli <|> configLibraryFile yaml
+      useLibraries
+        = maybe True id (configUseLibraries cli <|> configUseLibraries yaml)
+      useDefaultLibraries
+        = maybe True id (configUseDefaultLibraries cli <|> configUseDefaultLibraries yaml)
+
+  includePaths
+    <- traverse validateDirectory include
+  libraryPath
+    <- traverse validateFile libraryFile
+
+  pure
+    ( filePath
+    , globalMode
+    , filt
+    , UnusedOptions
+      { unusedOptionsInclude
+        = includePaths
+      , unusedOptionsLibraries
+        = libraries
+      , unusedOptionsLibrariesFile
+        = libraryPath
+      , unusedOptionsUseLibraries
+        = useLibraries
+      , unusedOptionsUseDefaultLibraries
+        = useDefaultLibraries
+      }
+    )
+
+replaceIfNonEmpty :: [a] -> [a] -> [a]
+replaceIfNonEmpty [] ys = ys
+replaceIfNonEmpty xs _  = xs
+
 -- ## Check
 
 check
   :: Options
   -> IO ()
 check opts = do
-  (filePath, opts')
-    <- optionsUnused opts
+  cwd
+    <- getCurrentDirectory
+  let searchDir = case configFile (optionsConfig opts) of
+        Just f  -> takeDirectory f
+        Nothing -> cwd
+  mYaml
+    <- resolveConfig (optionsConfigMode opts) searchDir
+  (filePath, globalMode, filt, unusedOpts)
+    <- mergeValidateOpts (optionsConfig opts) mYaml
   _
-    <- checkWith opts' filePath (optionsGlobal opts) (optionsJSON opts)
+    <- checkWith cwd filt unusedOpts filePath globalMode (optionsJSON opts)
   pure ()
 
 checkWith
-  :: UnusedOptions
+  :: FilePath
+  -- ^ Current working directory for relative paths.
+  -> Maybe CategoryFilter
+  -- ^ Category filter for results.
+  -> UnusedOptions
   -- ^ Options to use.
   -> FilePath
   -- ^ Absolute path of the file to check.
@@ -241,12 +344,14 @@ checkWith
   -> Bool
   -- ^ Whether to format output as JSON.
   -> IO ()
-checkWith opts p False j
+checkWith cwd filt opts p False json
   = checkUnused opts p
-  >>= printResult j printUnusedItems
-checkWith opts p True j
+  >>= printResult json (printUnusedItems . filterUnusedItems filt . rel)
+  where rel = if json then id else relativizeUnusedItems cwd
+checkWith cwd filt opts p True json
   = checkUnusedGlobal opts p
-  >>= printResult j printUnused
+  >>= printResult json (printUnused . filterUnused filt . rel)
+  where rel = if json then id else relativizeUnused cwd
 
 -- ## Print
 
@@ -293,4 +398,3 @@ main
 main
   = execParser options
   >>= check
-

--- a/data/declaration/CrossFile.agda
+++ b/data/declaration/CrossFile.agda
@@ -1,0 +1,10 @@
+module CrossFile where
+
+import CrossFileDep
+open import Agda.Builtin.Bool
+
+-- 'open import Agda.Builtin.Bool' has byte range 45–74, which
+-- contains CrossFileDep's 'true' at 70–74.  Without the fix (setting
+-- module names on RangeFile), Ord treats ranges from both files as
+-- same-file, and stateItemsFilter drops 'true' because its range is
+-- contained by the import range.

--- a/data/declaration/CrossFileDep.agda
+++ b/data/declaration/CrossFileDep.agda
@@ -1,0 +1,7 @@
+module CrossFileDep where
+open import Agda.Builtin.Bool using (Bool; true; false)
+x : Bool
+x = false
+
+-- 'true' (unused) has byte range 70–74.
+-- See CrossFile.agda for the cross-file overlap this tests.

--- a/data/declaration/Instance.agda
+++ b/data/declaration/Instance.agda
@@ -1,0 +1,43 @@
+module Instance where
+
+postulate
+
+  A : Set
+
+  f
+    : A
+    → A
+
+private
+
+  postulate
+
+    g
+      : A
+      → A
+
+  instance
+
+    postulate
+
+      g'
+        : A
+        → A
+
+    g''
+      : A
+      → A
+    g'' x
+      = f x
+
+instance
+
+  postulate
+
+    i : A
+
+h
+  : A
+  → A
+h x
+  = f x

--- a/data/declaration/LeftLet.agda
+++ b/data/declaration/LeftLet.agda
@@ -1,0 +1,17 @@
+module LeftLet where
+
+record Pair (A B : Set) : Set where
+  constructor _,_
+  field
+    fst : A
+    snd : B
+
+-- Only used in the 'using' expression; tests that checkExpr marks it used.
+wrap : {A B : Set} → Pair A B → Pair A B
+wrap p = p
+
+-- 'a' is used in the body, 'b' is not.
+-- Tests both used and unused pattern variables in the same 'using' clause.
+-- 'wrap' is used in the expression; tests expression-side name tracking.
+f : {A B : Set} → Pair A B → A
+f p using (a , b) ← wrap p = a

--- a/data/declaration/LetPattern.agda
+++ b/data/declaration/LetPattern.agda
@@ -1,0 +1,20 @@
+module LetPattern where
+
+record _×_ (A B : Set) : Set where
+  constructor _,_
+  field
+    fst : A
+    snd : B
+
+data Id {A : Set} : A → A → Set where
+  refl : {x : A} → Id x x
+
+-- Only used in the let-pattern RHS; tests that NiceFunClause's checkRHS
+-- marks it as used.
+split : {A B : Set} → A × B → A × B
+split p = p
+
+-- 'a' is used in the return type; 'b' is not.
+-- Tests that let-pattern bindings are exported to subsequent declarations.
+f : {A B : Set} → (p : A × B) → (let (a , b) = split p) → Id a a
+f _ = refl

--- a/data/declaration/OperatorSection.agda
+++ b/data/declaration/OperatorSection.agda
@@ -1,0 +1,7 @@
+module OperatorSection where
+
+open import Agda.Builtin.Nat using (Nat; _+_)
+
+-- Use _+_ in a left section — should NOT be reported unused.
+f : Nat → Nat → Nat
+f x = x +_

--- a/data/declaration/QualifiedHelper.agda
+++ b/data/declaration/QualifiedHelper.agda
@@ -1,0 +1,6 @@
+module QualifiedHelper where
+
+module Sub where
+  postulate
+    A : Set
+    a : A

--- a/data/declaration/QualifiedName.agda
+++ b/data/declaration/QualifiedName.agda
@@ -1,0 +1,11 @@
+module QualifiedName where
+
+-- suc is imported but only used qualified as N.suc.
+-- Only suc (as an unused unqualified item) should be reported.
+open import Agda.Builtin.Nat as N using (suc)
+
+postulate
+  n : N.Nat
+
+f : N.Nat
+f = N.suc n

--- a/data/declaration/RecordInstance.agda
+++ b/data/declaration/RecordInstance.agda
@@ -1,0 +1,36 @@
+module RecordInstance where
+
+record R : Set₁ where
+  field
+    A : Set
+    B : Set
+
+postulate
+  instance r : R
+
+-- SectionApp path (explicit arg): anonymous open, B unused
+open R r using (A; B)
+
+postulate
+  a : A
+
+-- SectionApp path (explicit arg): named DontOpen, M.A used
+module M = R r
+
+postulate
+  b : M.A
+
+-- RecordModuleInstance path (⦃ ... ⦄): named DontOpen, N.B used
+module N = R ⦃ ... ⦄
+
+postulate
+  c : N.B
+
+-- RecordModuleInstance path (⦃ ... ⦄): anonymous DoOpen, open & A unused
+open R ⦃ ... ⦄ using (A)
+
+-- RecordModuleInstance path (⦃ ... ⦄): anonymous DoOpen, A' unused but open used
+open R ⦃ ... ⦄ renaming (A to A'; B to B')
+
+postulate
+  d : B'

--- a/data/declaration/SubModuleOpen.agda
+++ b/data/declaration/SubModuleOpen.agda
@@ -1,0 +1,10 @@
+module SubModuleOpen where
+
+-- open import followed by open of a sub-module.
+-- Opening the sub-module should mark the import as used.
+open import QualifiedHelper
+
+open QualifiedHelper.Sub
+
+f : A
+f = a

--- a/data/declaration/SuppressDefinition.agda
+++ b/data/declaration/SuppressDefinition.agda
@@ -1,0 +1,13 @@
+{-# OPTIONS --rewriting #-}
+module SuppressDefinition where
+
+open import Agda.Builtin.Equality using (_≡_; refl)
+open import Agda.Builtin.Nat using (_+_)
+
+private
+  postulate
+    +0 : ∀ n → n + 0 ≡ n -- agda-unused: ignore
+    +0' : ∀ n → n + 0 ≡ n
+
+{-# BUILTIN REWRITE _≡_ #-}
+{-# REWRITE +0 #-}

--- a/data/declaration/SuppressImport.agda
+++ b/data/declaration/SuppressImport.agda
@@ -1,0 +1,14 @@
+module SuppressImport where
+
+open import Agda.Builtin.Bool
+  using (Bool; false; true) -- agda-unused: ignore
+open import Agda.Builtin.Nat
+  using (Nat; zero)
+open import Instance -- agda-unused: instances
+  using (A)
+
+g : Nat
+g = zero
+
+f : Bool
+f = false

--- a/data/declaration/WhereWith.agda
+++ b/data/declaration/WhereWith.agda
@@ -1,0 +1,15 @@
+module WhereWith where
+
+record Pair (A B : Set) : Set where
+  field
+    fst : A
+    snd : B
+
+swap : {A B : Set} → Pair A B → Pair B A
+swap p with fst | snd
+         where open Pair p
+... | a | b = record { fst = b ; snd = a }
+
+-- 'g' is unused
+g : {A : Set} → A → A
+g x = x

--- a/data/expression/Let.agda
+++ b/data/expression/Let.agda
@@ -66,3 +66,15 @@ m
 m a
   = let module M = Id a in M.value
 
+module Plain where
+  plain-val : Set₁
+  plain-val = Set
+
+-- let open plain module (NiceOpen path): plain-val used
+p : Set₁
+p = let open Plain in plain-val
+
+-- let open plain module (NiceOpen path): open unused
+q : {A : Set} → A → A
+q x = let open Plain in x
+

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1687886075,
-        "narHash": "sha256-PeayJDDDy+uw1Ats4moZnRdL1OFuZm1Tj+KiHlD67+o=",
+        "lastModified": 1774701658,
+        "narHash": "sha256-CIS/4AMUSwUyC8X5g+5JsMRvIUL3YUfewe8K4VrbsSQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a565059a348422af5af9026b5174dc5c0dcefdae",
+        "rev": "b63fe7f000adcfa269967eeff72c64cafecbbebe",
         "type": "github"
       },
       "original": {

--- a/src/Agda/Unused/Check.hs
+++ b/src/Agda/Unused/Check.hs
@@ -943,11 +943,23 @@ checkLHS
   => AccessContext
   -> LHS
   -> m AccessContext
-checkLHS c (LHS p rs ws)
+checkLHS c (LHS p rs _)
   = checkPattern c p
   >>= \c' -> checkRewriteEqns (c <> c') rs
-  >>= \c'' -> checkExprs (c <> c' <> c'') (unArg . namedThing <$> ws)
-  >> pure (c' <> c'')
+  >>= \c'' -> pure (c' <> c'')
+
+-- | Check with-expressions from an LHS, using a context that includes
+-- the where-clause bindings (needed for @with ... where open ...@).
+checkWithExprs
+  :: MonadError Error m
+  => MonadReader Environment m
+  => MonadState State m
+  => MonadIO m
+  => AccessContext
+  -> LHS
+  -> m ()
+checkWithExprs c (LHS _ _ ws)
+  = checkExprs c (unArg . namedThing <$> ws)
 
 checkRHS
   :: MonadError Error m
@@ -962,6 +974,23 @@ checkRHS _ AbsurdRHS
 checkRHS c (RHS e)
   = checkExpr c e
 
+checkFunClause
+  :: MonadError Error m
+  => MonadReader Environment m
+  => MonadState State m
+  => MonadIO m
+  => AccessContext
+  -> LHS
+  -> RHS
+  -> WhereClause
+  -> m (AccessContext, AccessContext)
+checkFunClause c l r w
+  = checkLHS c l
+  >>= \c' -> checkWhereClause (c <> c') w
+  >>= \(m, c'') -> checkWithExprs (c <> c' <> c'') l
+  >> checkRHS (c <> c' <> c'') r
+  >> pure (c', m)
+
 checkClause
   :: MonadError Error m
   => MonadReader Environment m
@@ -972,10 +1001,8 @@ checkClause
   -> m AccessContext
 checkClause c (Clause n _ l r w cs)
   = pure (maybe id accessContextDefine (fromName n) c)
-  >>= \c' -> checkLHS c' l
-  >>= \c'' -> checkWhereClause (c' <> c'') w
-  >>= \(m, c''') -> checkRHS (c' <> c'' <> c''') r
-  >> checkClauses (c' <> c'' <> c''') cs
+  >>= \c' -> checkFunClause c' l r w
+  >>= \(c'', m) -> checkClauses (c' <> c'' <> m) cs
   >>= \m' -> pure (m <> m')
 
 checkClauses
@@ -1490,8 +1517,7 @@ checkNiceDeclarationLet fs c
 checkNiceDeclarationLet _ c
   (NiceFunClause _ _ _ _ _ _
     (Concrete.FunClause l r NoWhere _))
-  = checkRHS c r
-  >> checkLHS c l
+  = fst <$> checkFunClause c l r NoWhere
 checkNiceDeclarationLet _ _ d
   = throwError (ErrorInternal (ErrorLet (getRange d)))
 

--- a/src/Agda/Unused/Check.hs
+++ b/src/Agda/Unused/Check.hs
@@ -1517,6 +1517,9 @@ checkNiceDeclarationLet fs c
 checkNiceDeclarationLet fs c
   d@(NiceModuleMacro _ _ _ _ _ _ _)
   = checkNiceDeclaration fs c d
+checkNiceDeclarationLet fs c
+  d@(NiceOpen _ _ _)
+  = checkNiceDeclaration fs c d
 checkNiceDeclarationLet _ c
   (NiceFunClause _ _ _ _ _ _
     (Concrete.FunClause l r NoWhere _))

--- a/src/Agda/Unused/Check.hs
+++ b/src/Agda/Unused/Check.hs
@@ -52,7 +52,8 @@ import Agda.Utils.FileId
 import Agda.Interaction.Library
   (getPrimitiveLibDir)
 import Agda.Interaction.Library.Base
-  (parseLibName)
+  (LibError(..), LibError'(..), LibErrors(..),
+    LibName(..), LibrariesFile(..), parseLibName)
 import Agda.Interaction.Options
   (CommandLineOptions(..), defaultOptions)
 import Agda.Syntax.Common
@@ -90,7 +91,7 @@ import Agda.Syntax.TopLevelModuleName
     rawTopLevelModuleNameForModule, rawTopLevelModuleNameForQName,
     unsafeTopLevelModuleName)
 import Agda.TypeChecking.Monad.Base
-  (TCM, runTCMTop)
+  (Closure(..), TCErr(..), TCM, TypeError(..), runTCMTop)
 import Agda.TypeChecking.Monad.Options
   (getIncludeDirs, setCommandLineOptions)
 import Agda.Utils.FileName
@@ -114,7 +115,7 @@ import Data.Foldable
 import qualified Data.List.NonEmpty
   as NonEmpty
 import Data.List.NonEmpty
-  (NonEmpty(..), nonEmpty)
+  (NonEmpty(..), nonEmpty, toList)
 import qualified Data.Map.Strict
   as Map
 import Data.Maybe
@@ -2094,7 +2095,7 @@ checkFileTop' m opts p = do
   includesEither
     <- liftIO (runTCMTop (setOptions opts >> getIncludeDirs))
   includes
-    <- liftEither (mapLeft (const ErrorInclude) includesEither)
+    <- liftEither (mapLeft (ErrorInclude . showTCErr) includesEither)
   env
     <- pure (Environment m rootPath includes)
   _
@@ -2269,4 +2270,31 @@ inFile
   -> Bool
 inFile p (r, _)
   = rangePath r == Just p
+
+showTCErr :: TCErr -> String
+showTCErr (TypeError _ _ cl)
+  = showTypeError (clValue cl)
+showTCErr (IOException _ _ e)
+  = show e
+showTCErr (GenericException s)
+  = s
+showTCErr e
+  = show e
+
+showTypeError :: TypeError -> String
+showTypeError (LibraryError errs)
+  = unlines (map showLibError (toList (libErrors errs)))
+showTypeError e
+  = show e
+
+showLibError :: LibError -> String
+showLibError (LibError _ (LibNotFound lf ln))
+  = "Library '" ++ T.unpack (libNameBase ln) ++ "' not found."
+  ++ " Libraries file: " ++ lfPath lf
+showLibError (LibError _ (LibrariesFileNotFound p))
+  = "Libraries file not found: " ++ p
+showLibError (LibError _ (AmbiguousLib ln _))
+  = "Ambiguous library '" ++ T.unpack (libNameBase ln) ++ "'."
+showLibError e
+  = show e
 

--- a/src/Agda/Unused/Check.hs
+++ b/src/Agda/Unused/Check.hs
@@ -1410,23 +1410,31 @@ checkNiceDeclaration' _ _ (NiceImport r n Nothing DontOpen i)
   >>= \n' -> checkFile r n'
   >>= \c' -> checkImportDirective Import r n' c' i
   >>= \c'' -> pure (accessContextImport n' c'')
+-- FIXME: Both qualified access (via the module name) and unqualified access
+-- (via the open) are stamped with the same range r, so we cannot separately
+-- report an unused open when only qualified access is used.
 checkNiceDeclaration' _ _ (NiceImport r n Nothing DoOpen i)
   = liftMaybe (ErrorInternal (ErrorName (getRange n))) (fromQName n)
   >>= \n' -> checkFile r n'
   >>= \c' -> checkImportDirective Import r n' c' i
-  >>= \c'' -> pure (accessContextImport n' c'
+  >>= \c'' -> contextInsertRangeAll r c' -- stamp full context for qualified access
+  >>= \c'r -> pure (accessContextImport n' c'r
     <> fromContext (importDirectiveAccess i) c'')
 checkNiceDeclaration' _ _ (NiceImport r n (Just a) DontOpen i)
   = liftMaybe (ErrorInternal (ErrorName (getRange n))) (fromQName n)
   >>= \n' -> checkFile r n'
   >>= \c' -> checkImportDirective Import r n' c' i
   >>= \c'' -> checkModuleNameMay c'' Public (getRange a) (fromAsName a)
+-- FIXME: Same as above — qualified access (via the alias) and unqualified
+-- access (via the open) share range r.  If only N.foo is used, the open is
+-- redundant but not reported; the module alias is correctly marked used.
 checkNiceDeclaration' _ _ (NiceImport r n (Just a) DoOpen i)
   = liftMaybe (ErrorInternal (ErrorName (getRange n))) (fromQName n)
   >>= \n' -> checkFile r n'
   >>= \c' -> checkImportDirective Import r n' c' i
-  >>= \c'' -> checkModuleNameMay c' Public (getRange a) (fromAsName a)
-  >>= \c''' -> pure (c''' <> fromContext (importDirectiveAccess i) c'')
+  >>= \c'' -> contextInsertRangeAll r c' -- stamp full context for qualified access
+  >>= \c'r -> checkModuleNameMay c'r Public (getRange a) (fromAsName a)
+  >>= \c''' -> pure (fromContext (importDirectiveAccess i) c'' <> c''')
 
 checkNiceDeclaration' fs c (NicePatternSyn _ a n ns p)
   = localSkip (checkNames' False Public RangeVariable (whThing <$> ns))
@@ -1769,6 +1777,9 @@ checkModuleApp c a r a' n o i
     _ -> liftMaybe (ErrorInternal (ErrorName (getRange a'))) (fromName a')
       >>= \a'' -> checkImportDirective Module r (QName a'') c' i
       >>= \c''' -> checkModuleName c''' a r a''
+      -- FIXME: Same open-vs-alias conflation as NiceImport DoOpen — qualified
+      -- and unqualified access share the same range, so a redundant open is
+      -- not detected.
       >>= \c'''' -> case o of
         DontOpen -> pure c''''
         DoOpen -> pure (c'''' <> fromContext (importDirectiveAccess i) c''')

--- a/src/Agda/Unused/Check.hs
+++ b/src/Agda/Unused/Check.hs
@@ -2092,7 +2092,7 @@ checkFilePath
   -> FilePath
   -> m Context
 checkFilePath n p = do
-  (module', sm) <- readModule p
+  (module', sm) <- readModule (Just n) p
   localSuppressions sm (checkModule n module')
 
 checkFileTop
@@ -2120,7 +2120,7 @@ checkFileTop'
   -- ^ The project root.
 checkFileTop' m opts p = do
   (module', sm)
-    <- readModule p
+    <- readModule Nothing p
   rawModuleName
     <- pure (rawTopLevelModuleNameForModule module')
   moduleName
@@ -2143,18 +2143,32 @@ checkFileTop' m opts p = do
 
 readModule
   :: MonadError Error m
+  => MonadState State m
   => MonadIO m
-  => FilePath
+  => Maybe QName
+  -- ^ If known, the module name (avoids a redundant parse).
+  -> FilePath
   -> m (Module, SuppressionMap)
-readModule p = do
+readModule mn p = do
   exists
     <- liftIO (doesFileExist p)
   _
     <- unless exists (throwError (ErrorFile p))
-  rangeFile
-    <- pure (RangeFile (mkAbsolute p) Nothing)
+  let absPath = mkAbsolute p
   contents
     <- liftIO (readFile p)
+  -- The Ord instance for RangeFile compares only module names, so we must
+  -- set the module name to distinguish ranges from different files with
+  -- overlapping positions (avoiding false negatives in the state map).
+  let parseName = do
+        (pre, _) <- liftIO (runPMIO (parseFile moduleParser
+                      (RangeFile absPath Nothing) contents))
+        ((m, _), _) <- liftEither (mapLeft ErrorParse pre)
+        pure (fromModuleName (rawTopLevelModuleNameForModule m))
+  moduleQName <- maybe parseName pure mn
+  modName
+    <- topLevelModuleName (rawTopLevelModuleNameForQName (toQName moduleQName))
+  let rangeFile = RangeFile absPath (Just modName)
   (parseResult, _)
     <- liftIO (runPMIO (parseFile moduleParser rangeFile contents))
   ((module', _), _)
@@ -2162,7 +2176,7 @@ readModule p = do
   (lexResult, _)
     <- liftIO (runPMIO (parseFile tokensParser rangeFile contents))
   let suppressions = case lexResult of
-        Right ((tokens, _), _) -> extractSuppressions (filePath (mkAbsolute p)) tokens
+        Right ((tokens, _), _) -> extractSuppressions (filePath absPath) tokens
         Left _                 -> mempty
   pure (module', suppressions)
 

--- a/src/Agda/Unused/Check.hs
+++ b/src/Agda/Unused/Check.hs
@@ -1095,8 +1095,8 @@ checkRewriteEqn c (Rewrite rs)
   = checkExprs1 c (snd <$> rs) >> pure mempty
 checkRewriteEqn c (Invert _ ws)
   = checkIrrefutableWiths c (namedThing <$> ws)
-checkRewriteEqn _ (LeftLet pes)
-  = throwError (ErrorUnsupported UnsupportedLeftLet (getRange pes))
+checkRewriteEqn c (LeftLet pes)
+  = checkIrrefutableWiths c pes
 
 checkRewriteEqns
   :: MonadError Error m

--- a/src/Agda/Unused/Check.hs
+++ b/src/Agda/Unused/Check.hs
@@ -16,11 +16,13 @@ import Agda.Unused.Monad.Error
     liftLookup)
 import Agda.Unused.Monad.Reader
   (Environment(..), Mode(..), askGlobalMain, askIncludes, askLocal, askRoot,
-    askSkip, localGlobal, localSkip)
+    askSkip, localGlobal, localSkip, localSuppressions)
 import Agda.Unused.Monad.State
   (ModuleState(..), State, getHash, getModule, getSources, modifyBlock,
     modifyCheck, modifyDelete, modifyInsert, modifySources, stateEmpty,
     stateItems, stateModules)
+import Agda.Unused.Suppress
+  (SuppressionMap, extractSuppressions)
 import Agda.Unused.Types.Access
   (Access(..), fromAccess)
 import Agda.Unused.Types.Context
@@ -83,7 +85,7 @@ import Agda.Syntax.Concrete.Name
 import qualified Agda.Syntax.Concrete.Name
   as N
 import Agda.Syntax.Parser
-  (moduleParser, parseFile, runPMIO)
+  (moduleParser, parseFile, runPMIO, tokensParser)
 import Agda.Syntax.Position
   (Range, Range'(..), RangeFile(..), getRange)
 import Agda.Syntax.TopLevelModuleName
@@ -2089,9 +2091,9 @@ checkFilePath
   => QName
   -> FilePath
   -> m Context
-checkFilePath n p
-  = readModule p
-  >>= checkModule n
+checkFilePath n p = do
+  (module', sm) <- readModule p
+  localSuppressions sm (checkModule n module')
 
 checkFileTop
   :: MonadError Error m
@@ -2117,7 +2119,7 @@ checkFileTop'
   -> m FilePath
   -- ^ The project root.
 checkFileTop' m opts p = do
-  module'
+  (module', sm)
     <- readModule p
   rawModuleName
     <- pure (rawTopLevelModuleNameForModule module')
@@ -2134,7 +2136,7 @@ checkFileTop' m opts p = do
   includes
     <- liftEither (mapLeft (ErrorInclude . showTCErr) includesEither)
   env
-    <- pure (Environment m rootPath includes)
+    <- pure (Environment m rootPath includes sm)
   _
     <- runReaderT (checkModule moduleQName module') env
   pure rootPath
@@ -2143,7 +2145,7 @@ readModule
   :: MonadError Error m
   => MonadIO m
   => FilePath
-  -> m Module
+  -> m (Module, SuppressionMap)
 readModule p = do
   exists
     <- liftIO (doesFileExist p)
@@ -2157,7 +2159,12 @@ readModule p = do
     <- liftIO (runPMIO (parseFile moduleParser rangeFile contents))
   ((module', _), _)
     <- liftEither (mapLeft ErrorParse parseResult)
-  pure module'
+  (lexResult, _)
+    <- liftIO (runPMIO (parseFile tokensParser rangeFile contents))
+  let suppressions = case lexResult of
+        Right ((tokens, _), _) -> extractSuppressions (filePath (mkAbsolute p)) tokens
+        Left _                 -> mempty
+  pure (module', suppressions)
 
 topLevelModuleName
   :: MonadState State m

--- a/src/Agda/Unused/Check.hs
+++ b/src/Agda/Unused/Check.hs
@@ -44,13 +44,21 @@ import Agda.Unused.Utils
   (liftMaybe, mapLeft)
 
 import Agda.Interaction.FindFile
-  (findFile'', srcFilePath)
+  (SourceFile(..), findFile'')
+import Agda.TypeChecking.Monad.Base
+  (ModuleToSource(..), FileDictWithBuiltins(..))
+import Agda.Utils.FileId
+  (GetIdFile(..))
+import Agda.Interaction.Library
+  (getPrimitiveLibDir)
+import Agda.Interaction.Library.Base
+  (parseLibName)
 import Agda.Interaction.Options
   (CommandLineOptions(..), defaultOptions)
 import Agda.Syntax.Common
   (Arg(..), Fixity'(..), ImportDirective'(..), ImportedName'(..),
-    Named(..), NotationPart(..), Ranged(..), RecordDirectives'(..), Renaming'(..),
-    RewriteEqn'(..), Using'(..), namedThing, unArg)
+    Named(..), NotationPart(..), Ranged(..), Renaming'(..),
+    RewriteEqn'(..), Using'(..), namedThing, unArg, whThing)
 import qualified Agda.Syntax.Common
   as Common
 import Agda.Syntax.Concrete
@@ -58,12 +66,15 @@ import Agda.Syntax.Concrete
     FieldAssignment, FieldAssignment'(..), ImportDirective, ImportedName,
     LamBinding, LamBinding'(..), LamClause(..), LHS(..), Module(..),
     ModuleApplication(..), ModuleAssignment(..), OpenShortHand(..), Pattern(..),
-    RecordAssignment, RecordDirectives, Renaming, RewriteEqn, RHS, RHS'(..),
-    TypedBinding, TypedBinding'(..), WhereClause, WhereClause'(..), _exprFieldA)
+    RecordAssignment, RecordDirective(..), Renaming, RewriteEqn, RHS, RHS'(..),
+    TypedBinding, TypedBinding'(..), WhereClause, WhereClause'(..), WhereClause_(..),
+    _exprFieldA)
 import qualified Agda.Syntax.Concrete
   as Concrete
 import Agda.Syntax.Concrete.Definitions
   (Clause(..), NiceConstructor, NiceDeclaration(..), niceDeclarations, runNice)
+import Agda.Syntax.Concrete.Definitions.Monad
+  (NiceEnv(..))
 import Agda.Syntax.Concrete.Fixity
   (DoWarn(..), Fixities, fixitiesAndPolarities)
 import Agda.Syntax.Concrete.Name
@@ -86,8 +97,6 @@ import Agda.Utils.FileName
   (filePath, mkAbsolute)
 import qualified Agda.Utils.List2
   as List2
-import Agda.Utils.List2
-  (List2(..))
 import Control.Monad
   (foldM, unless, void, when)
 import Control.Monad.Except
@@ -109,7 +118,7 @@ import Data.List.NonEmpty
 import qualified Data.Map.Strict
   as Map
 import Data.Maybe
-  (catMaybes)
+  (catMaybes, listToMaybe, mapMaybe)
 import Data.Set
   (Set)
 import qualified Data.Set
@@ -420,7 +429,7 @@ checkBinder
   -> AccessContext
   -> Binder
   -> m AccessContext
-checkBinder b c (Binder p (BName n _ _ _))
+checkBinder b c (Binder p _ (BName n _ _ _))
   = bool localSkip id b (checkName' False mempty Public RangeVariable n)
   >>= \c' -> checkPatternMay c p
   >>= \c'' -> pure (c' <> c'')
@@ -549,7 +558,7 @@ checkPatternRec
   -> AccessContext
   -> Pattern
   -> m AccessContext
-checkPatternRec r c (IdentP n)
+checkPatternRec r c (IdentP _ n)
   = maybe (pure mempty) (uncurry (checkIdentP r c)) (fromQNameRange n)
 checkPatternRec _ _ (QuoteP _)
   = pure mempty
@@ -573,14 +582,14 @@ checkPatternRec _ _ (AbsurdP _)
 checkPatternRec r c (AsP _ n p)
   = (<>) <$> maybe (pure mempty) (uncurry (checkAsP r)) (fromNameRange n)
     <*> checkPatternRec r c p
-checkPatternRec _ c (DotP _ e)
+checkPatternRec _ c (DotP _ _ e)
   = checkExpr c e >> pure mempty
 checkPatternRec _ _ (LitP _ _)
   = pure mempty
-checkPatternRec _ c (RecP _ as)
+checkPatternRec _ c (RecP _ _ as)
   = checkSequence checkPattern c (_exprFieldA <$> as)
 checkPatternRec _ c (EqualP _ es)
-  = checkExprPairs c es >> pure mempty
+  = checkExprPairs c (NonEmpty.toList es) >> pure mempty
 checkPatternRec _ _ (EllipsisP _ _)
   = pure mempty
 checkPatternRec r c (WithP _ p)
@@ -696,7 +705,7 @@ patternDelete ns
 patternName
   :: Pattern
   -> Maybe String
-patternName (IdentP (N.QName (N.Name _ _ (Id n :| []))))
+patternName (IdentP _ (N.QName (N.Name _ _ (Id n :| []))))
   = Just n
 patternName _
   = Nothing
@@ -719,6 +728,12 @@ checkExpr
   -> m ()
 checkExpr c (Ident n)
   = touchQName' c n
+checkExpr c (KnownIdent _ n)
+  = touchQName' c n
+-- Produced by operator resolution during scope checking; unreachable
+-- since we only parse (the parser produces RawApp instead).
+checkExpr _ (KnownOpApp _ r _ _ _)
+  = throwError (ErrorInternal (ErrorUnexpected UnexpectedOpApp r))
 checkExpr _ (Lit _ _)
   = pure ()
 checkExpr _ (QuestionMark _ _)
@@ -732,7 +747,7 @@ checkExpr c (App _ e (Arg _ (Named _ e')))
 checkExpr _ (OpApp r _ _ _)
   = throwError (ErrorInternal (ErrorUnexpected UnexpectedOpApp r))
 checkExpr c (WithApp _ e es)
-  = checkExpr c e >> checkExprs c es
+  = checkExpr c e >> checkExprs c (NonEmpty.toList es)
 checkExpr c (HiddenArg _ (Named _ e))
   = checkExpr c e
 checkExpr c (InstanceArg _ (Named _ e))
@@ -747,9 +762,9 @@ checkExpr c (Fun _ (Arg _ e) e')
   = checkExpr c e >> checkExpr c e'
 checkExpr c (Pi bs e)
   = checkTypedBindings1 True c bs >>= \c' -> checkExpr (c <> c') e
-checkExpr c (Rec _ rs)
+checkExpr c (Rec _ _ rs)
   = checkRecordAssignments c rs
-checkExpr c (RecUpdate _ e fs)
+checkExpr c (RecUpdate _ _ e fs)
   = checkExpr c e >> checkFieldAssignments c fs
 checkExpr c (Let _ ds e)
   = checkDeclarationsLet1 c ds >>= \c' -> traverse_ (checkExpr (c <> c')) e
@@ -1031,7 +1046,7 @@ checkWhereClause _ NoWhere
 checkWhereClause c (AnyWhere _ ds)
   = checkDeclarations c ds
   >>= \c' -> pure (mempty, c')
-checkWhereClause c (SomeWhere _ n a ds)
+checkWhereClause c (SomeWhere _ _ n a ds)
   = checkDeclarations c ds
   >>= \c' -> checkModuleNameMay (toContext c') (fromAccess a) (getRange n)
     (fromName n)
@@ -1049,6 +1064,8 @@ checkRewriteEqn c (Rewrite rs)
   = checkExprs1 c (snd <$> rs) >> pure mempty
 checkRewriteEqn c (Invert _ ws)
   = checkIrrefutableWiths c (namedThing <$> ws)
+checkRewriteEqn _ (LeftLet pes)
+  = throwError (ErrorUnsupported UnsupportedLeftLet (getRange pes))
 
 checkRewriteEqns
   :: MonadError Error m
@@ -1234,8 +1251,8 @@ checkDeclarationsWith
 checkDeclarationsWith f c ds = do
   (fixities, _)
     <- fixitiesAndPolarities NoWarn ds
-  (niceDeclsEither, _) 
-    <- pure (runNice (niceDeclarations fixities ds))
+  (niceDeclsEither, _)
+    <- pure (runNice (NiceEnv False NoWhere_) (niceDeclarations fixities ds))
   niceDecls
     <- liftEither (mapLeft ErrorDeclaration niceDeclsEither)
   f fixities c niceDecls
@@ -1288,17 +1305,17 @@ checkNiceDeclaration' _ _ (NiceField r _ _ _ _ _ _)
   = throwError (ErrorInternal (ErrorUnexpected UnexpectedField r))
 checkNiceDeclaration' fs c (PrimitiveFunction _ a _ n (Arg _ e))
   = checkExpr c e >> checkName' False fs (fromAccess a) RangeDefinition n
-checkNiceDeclaration' _ c (NiceModule r a _ (N.QName n) bs ds)
+checkNiceDeclaration' _ c (NiceModule r a _ _ (N.QName n) bs ds)
   = checkNiceModule c (fromAccess a) r (fromName n) bs ds
-checkNiceDeclaration' _ _ (NiceModule _ _ _ n@(N.Qual _ _) _ _)
+checkNiceDeclaration' _ _ (NiceModule _ _ _ _ n@(N.Qual _ _) _ _)
   = throwError (ErrorInternal (ErrorName (getRange n)))
-checkNiceDeclaration' _ c (NiceModuleMacro r a n m o i)
+checkNiceDeclaration' _ c (NiceModuleMacro r a _ n m o i)
   = checkNiceModuleMacro c (fromAccess a) r n m o i
 checkNiceDeclaration' _ _ (NicePragma _ _)
   = pure mempty
-checkNiceDeclaration' fs c (NiceRecSig _ a _ _ _ n bs e)
+checkNiceDeclaration' fs c (NiceRecSig _ _ a _ _ _ n bs e)
   = checkNiceSig fs c a RangeRecord n bs e
-checkNiceDeclaration' fs c (NiceDataSig _ a _ _ _ n bs e)
+checkNiceDeclaration' fs c (NiceDataSig _ _ a _ _ _ n bs e)
   = checkNiceSig fs c a RangeData n bs e
 checkNiceDeclaration' _ _ (NiceFunClause r _ _ _ _ _ _)
   = throwError (ErrorInternal (ErrorUnexpected UnexpectedNiceFunClause r))
@@ -1309,7 +1326,7 @@ checkNiceDeclaration' _ c (FunDef _ _ _ _ _ _ _ cs)
 checkNiceDeclaration' fs c (NiceDataDef _ _ _ _ _ n bs cs)
   = checkNiceDataDef True fs c n bs cs
 checkNiceDeclaration' _ _ (NiceLoneConstructor r _)
-  = throwError (ErrorUnsupported UnsupportedLoneConstructor r)
+  = throwError (ErrorUnsupported UnsupportedLoneConstructor (getRange r))
 checkNiceDeclaration' fs c (NiceRecDef _ _ _ _ _ n rs bs ds)
   = checkNiceRecordDef True fs c n rs bs ds
 checkNiceDeclaration' _ c (NiceGeneralize _ _ _ _ _ e)
@@ -1320,17 +1337,19 @@ checkNiceDeclaration' _ _ (NiceUnquoteDef r _ _ _ _ _ _)
   = throwError (ErrorUnsupported UnsupportedUnquote r)
 checkNiceDeclaration' _ _ (NiceUnquoteData r _ _ _ _ _ _ _)
   = throwError (ErrorUnsupported UnsupportedUnquote r)
+checkNiceDeclaration' fs c (NiceOpaque _ _ ds)
+  = checkNiceDeclarations fs c ds
 
 checkNiceDeclaration' fs c
   (NiceMutual _ _ _ _
-    (d@(NiceRecSig _ _ _ _ _ n _ _) : NiceRecDef _ _ _ _ _ n' rs bs ds : []))
+    (d@(NiceRecSig _ _ _ _ _ _ n _ _) : NiceRecDef _ _ _ _ _ n' rs bs ds : []))
   | nameRange n == nameRange n'
   = checkNiceDeclaration fs c d
   >>= \c' -> checkNiceRecordDef False fs (c <> c') n' rs bs ds
   >>= \c'' -> pure (c' <> c'')
 checkNiceDeclaration' fs c
   (NiceMutual _ _ _ _
-    (d@(NiceDataSig _ _ _ _ _ n _ _) : NiceDataDef _ _ _ _ _ n' bs cs : []))
+    (d@(NiceDataSig _ _ _ _ _ _ n _ _) : NiceDataDef _ _ _ _ _ n' bs cs : []))
   | nameRange n == nameRange n'
   = checkNiceDeclaration fs c d
   >>= \c' -> checkNiceDataDef False fs (c <> c') n' bs cs
@@ -1339,10 +1358,11 @@ checkNiceDeclaration' fs c
   (NiceMutual _ _ _ _
     ds@(FunSig _ _ _ _ _ _ _ _ _ _ : FunDef _ _ _ _ _ _ _ _ : []))
   = checkNiceDeclarations fs c ds
-checkNiceDeclaration' fs c (NiceMutual r _ _ _ ds)
+checkNiceDeclaration' fs c d@(NiceMutual _ _ _ _ ds)
   = checkNiceDeclarations fs c ds
   >>= \c' -> modifyInsert r RangeMutual
   >> accessContextInsertRangeAll r c'
+  where r = getRange d
 
 checkNiceDeclaration' _ c (NiceOpen r n i)
   = liftMaybe (ErrorInternal (ErrorName (getRange n))) (fromQName n)
@@ -1375,7 +1395,7 @@ checkNiceDeclaration' _ _ (NiceImport r n (Just a) DoOpen i)
   >>= \c''' -> pure (c''' <> fromContext (importDirectiveAccess i) c'')
 
 checkNiceDeclaration' fs c (NicePatternSyn _ a n ns p)
-  = localSkip (checkNames' False Public RangeVariable (unArg <$> ns))
+  = localSkip (checkNames' False Public RangeVariable (whThing <$> ns))
   >>= \c' -> checkPattern (c <> c') p
   >> checkName' True fs (fromAccess a) RangePatternSynonym n
 
@@ -1397,9 +1417,9 @@ checkNiceDeclarationRecord _ rs fs c d@(PrimitiveFunction _ _ _ _ _)
   = modifyDelete rs >> checkNiceDeclaration fs c d
 checkNiceDeclarationRecord n rs fs c (NiceMutual _ _ _ _ ds)
   = checkNiceDeclarationsRecord n rs fs c ds
-checkNiceDeclarationRecord _ rs fs c d@(NiceModule _ _ _ _ _ _)
+checkNiceDeclarationRecord _ rs fs c d@(NiceModule _ _ _ _ _ _ _)
   = modifyDelete rs >> checkNiceDeclaration fs c d
-checkNiceDeclarationRecord _ _ fs c d@(NiceModuleMacro _ _ _ _ _ _)
+checkNiceDeclarationRecord _ _ fs c d@(NiceModuleMacro _ _ _ _ _ _ _)
   = checkNiceDeclaration fs c d
 checkNiceDeclarationRecord _ _ fs c d@(NiceOpen _ _ _)
   = checkNiceDeclaration fs c d
@@ -1407,9 +1427,9 @@ checkNiceDeclarationRecord _ _ fs c d@(NiceImport _ _ _ _ _)
   = checkNiceDeclaration fs c d
 checkNiceDeclarationRecord _ _ fs c d@(NicePragma _ _)
   = checkNiceDeclaration fs c d
-checkNiceDeclarationRecord _ rs fs c d@(NiceRecSig _ _ _ _ _ _ _ _)
+checkNiceDeclarationRecord _ rs fs c d@(NiceRecSig _ _ _ _ _ _ _ _ _)
   = modifyDelete rs >> checkNiceDeclaration fs c d
-checkNiceDeclarationRecord _ rs fs c d@(NiceDataSig _ _ _ _ _ _ _ _)
+checkNiceDeclarationRecord _ rs fs c d@(NiceDataSig _ _ _ _ _ _ _ _ _)
   = modifyDelete rs >> checkNiceDeclaration fs c d
 checkNiceDeclarationRecord _ _ fs c d@(NiceFunClause _ _ _ _ _ _ _)
   = checkNiceDeclaration fs c d
@@ -1420,7 +1440,9 @@ checkNiceDeclarationRecord _ _ fs c d@(FunDef _ _ _ _ _ _ _ _)
 checkNiceDeclarationRecord _ _ fs c d@(NiceDataDef _ _ _ _ _ _ _ _)
   = checkNiceDeclaration fs c d
 checkNiceDeclarationRecord _ _ _ _ (NiceLoneConstructor r _)
-  = throwError (ErrorUnsupported UnsupportedLoneConstructor r)
+  = throwError (ErrorUnsupported UnsupportedLoneConstructor (getRange r))
+checkNiceDeclarationRecord _ _ fs c (NiceOpaque _ _ ds)
+  = checkNiceDeclarations fs c ds
 checkNiceDeclarationRecord _ _ fs c d@(NiceRecDef _ _ _ _ _ _ _ _ _)
   = checkNiceDeclaration fs c d
 checkNiceDeclarationRecord _ _ fs c d@(NicePatternSyn _ _ _ _ _)
@@ -1459,7 +1481,7 @@ checkNiceDeclarationLet fs c
   >>= \c' -> checkRHS (c <> c') r
   >> checkName' False fs Public RangeDefinition n
 checkNiceDeclarationLet fs c
-  d@(NiceModuleMacro _ _ _ _ _ _)
+  d@(NiceModuleMacro _ _ _ _ _ _ _)
   = checkNiceDeclaration fs c d
 checkNiceDeclarationLet _ c
   (NiceFunClause _ _ _ _ _ _
@@ -1519,7 +1541,7 @@ checkNiceDeclarationsTop
   -> m AccessContext
 checkNiceDeclarationsTop _ _ []
   = pure mempty
-checkNiceDeclarationsTop _ c (NiceModule r a _ _ bs ds : _)
+checkNiceDeclarationsTop _ c (NiceModule r a _ _ _ bs ds : _)
   = checkNiceModule c (fromAccess a) r Nothing bs ds
 checkNiceDeclarationsTop fs c (d : ds)
   = checkNiceDeclaration fs c d
@@ -1573,15 +1595,16 @@ checkNiceRecordDef
   -> Fixities
   -> AccessContext
   -> N.Name
-  -> RecordDirectives
+  -> [RecordDirective]
   -> [LamBinding]
   -> [Declaration]
   -> m AccessContext
-checkNiceRecordDef b fs c n (RecordDirectives _ _ _ m) bs ds
+checkNiceRecordDef b fs c n directives bs ds
   = liftMaybe (ErrorInternal (ErrorName (getRange n))) (fromName n)
   >>= \n' -> pure (either (const mempty) id (accessContextLookup (QName n') c))
   >>= \rs' -> checkLamBindings b c bs
-  >>= \c' -> checkNiceConstructorRecordMay fs rs' (m >>= fromNameRange . fst)
+  >>= \c' -> checkNiceConstructorRecordMay fs rs'
+        (listToMaybe (mapMaybe (\d -> case d of Constructor cn _ -> fromNameRange cn; _ -> Nothing) directives))
   >>= \c'' -> checkDeclarationsRecord n' rs' (c <> c') ds
   >>= \c''' -> pure (accessContextModule' n' Public rs' (c'' <> c''') <> c'')
 
@@ -1678,8 +1701,8 @@ checkNiceModuleMacro
   -> OpenShortHand
   -> ImportDirective
   -> m AccessContext
-checkNiceModuleMacro c a _ a' (SectionApp r bs e) o i
-  = checkSectionApp c a r a' bs (parseSectionApp e) o i
+checkNiceModuleMacro c a _ a' (SectionApp r bs n es) o i
+  = checkSectionApp c a r a' bs n es o i
 checkNiceModuleMacro _ _ r _ (RecordModuleInstance _ _) _ _
   = throwError (ErrorUnsupported UnsupportedMacro r)
 
@@ -1693,20 +1716,19 @@ checkSectionApp
   -> Range
   -> N.Name
   -> [TypedBinding]
-  -> Maybe (N.QName, [Expr])
+  -> N.QName
+  -> [Expr]
   -> OpenShortHand
   -> ImportDirective
   -> m AccessContext
-checkSectionApp _ _ r _ _ Nothing _ _
-  = throwError (ErrorInternal (ErrorMacro r))
-checkSectionApp c _ r (N.NoName _ _) [] (Just (n, es)) DoOpen i
+checkSectionApp c _ r (N.NoName _ _) [] n es DoOpen i
   = liftMaybe (ErrorInternal (ErrorName (getRange n))) (fromQName n)
   >>= \n' -> liftLookup r n' (accessContextLookupModule n' c)
   >>= \(C.Module rs c') -> modifyDelete rs
   >> checkExprs c es
   >> checkImportDirective Open r n' c' i
   >>= pure . fromContext (importDirectiveAccess i)
-checkSectionApp c a r a' bs (Just (n, es)) DontOpen i
+checkSectionApp c a r a' bs n es DontOpen i
   = liftMaybe (ErrorInternal (ErrorName (getRange n))) (fromQName n)
   >>= \n' -> liftMaybe (ErrorInternal (ErrorName (getRange a'))) (fromName a')
   >>= \a'' -> liftLookup r n' (accessContextLookupModule n' c)
@@ -1715,7 +1737,7 @@ checkSectionApp c a r a' bs (Just (n, es)) DontOpen i
   >>= \c'' -> checkExprs (c <> c'') es
   >> checkImportDirective Module r (QName a'') c' i
   >>= \c''' -> checkModuleName c''' a r a''
-checkSectionApp c a r a' bs (Just (n, es)) DoOpen i
+checkSectionApp c a r a' bs n es DoOpen i
   = liftMaybe (ErrorInternal (ErrorName (getRange n))) (fromQName n)
   >>= \n' -> liftMaybe (ErrorInternal (ErrorName (getRange a'))) (fromName a')
   >>= \a'' -> liftLookup r n' (accessContextLookupModule n' c)
@@ -1725,16 +1747,6 @@ checkSectionApp c a r a' bs (Just (n, es)) DoOpen i
   >> checkImportDirective Module r (QName a'') c' i
   >>= \c''' -> checkModuleName c''' a r a''
   >>= \c'''' -> pure (c'''' <> fromContext (importDirectiveAccess i) c''')
-
-parseSectionApp
-  :: Expr
-  -> Maybe (N.QName, [Expr])
-parseSectionApp (Ident n)
-  = Just (n, [])
-parseSectionApp (RawApp _ (List2 (Ident n) e es))
-  = Just (n, (e : es))
-parseSectionApp _
-  = Nothing
 
 -- ## Imports
 
@@ -2021,13 +2033,14 @@ checkFileExternal r n = do
   moduleName
     <- topLevelModuleName rawModuleName
   (pathEither, sources')
-    <- liftIO (findFile'' includes moduleName sources)
+    <- liftIO (runStateT (findFile'' includes moduleName) sources)
   path
     <- liftEither (mapLeft (ErrorFind r n) pathEither)
   _
     <- modifySources sources'
   context
-    <- localSkip (checkFilePath n (filePath (srcFilePath path)))
+    <- localSkip (checkFilePath n
+         (filePath (getIdFile (fileDictBuilder (fileDict sources')) (srcFileId path))))
   pure context
 
 checkFilePath
@@ -2051,8 +2064,9 @@ checkFileTop
   -- ^ The file to check.
   -> m (FilePath, State)
   -- ^ The project root, along with the final state.
-checkFileTop m opts p
-  = runStateT (checkFileTop' m opts p) stateEmpty
+checkFileTop m opts p = do
+  primLibDir <- liftIO getPrimitiveLibDir
+  runStateT (checkFileTop' m opts p) (stateEmpty primLibDir)
 
 checkFileTop'
   :: MonadError Error m
@@ -2240,7 +2254,7 @@ setOptions opts
   { optIncludePaths
     = unusedOptionsInclude opts
   , optLibraries
-    = T.unpack <$> unusedOptionsLibraries opts
+    = parseLibName . T.unpack <$> unusedOptionsLibraries opts
   , optOverrideLibrariesFile
     = unusedOptionsLibrariesFile opts
   , optDefaultLibs

--- a/src/Agda/Unused/Check.hs
+++ b/src/Agda/Unused/Check.hs
@@ -58,7 +58,7 @@ import Agda.Interaction.Options
   (CommandLineOptions(..), defaultOptions)
 import Agda.Syntax.Common
   (Arg(..), Fixity'(..), ImportDirective'(..), ImportedName'(..),
-    Named(..), NotationPart(..), Ranged(..), Renaming'(..),
+    IsInstance(..), Named(..), NotationPart(..), Ranged(..), Renaming'(..),
     RewriteEqn'(..), Using'(..), namedThing, unArg, whThing)
 import qualified Agda.Syntax.Common
   as Common
@@ -1330,8 +1330,9 @@ checkNiceDeclaration'
   -> NiceDeclaration
   -> m AccessContext
 
-checkNiceDeclaration' fs c (Axiom _ a _ _ _ n e)
+checkNiceDeclaration' fs c (Axiom _ a _ i _ n e)
   = checkExpr c e >> checkName' False fs (fromAccess a) RangePostulate n
+  >>= \c' -> markInstance i n >> pure c'
 checkNiceDeclaration' _ _ (NiceField r _ _ _ _ _ _)
   = throwError (ErrorInternal (ErrorUnexpected UnexpectedField r))
 checkNiceDeclaration' fs c (PrimitiveFunction _ a _ n (Arg _ e))
@@ -1353,8 +1354,9 @@ checkNiceDeclaration' _ c (NiceFunClause _ _ _ _ _ _
   = fst <$> checkFunClause c l r w
 checkNiceDeclaration' _ _ (NiceFunClause r _ _ _ _ _ _)
   = throwError (ErrorInternal (ErrorUnexpected UnexpectedNiceFunClause r))
-checkNiceDeclaration' fs c (FunSig _ a _ _ _ _ _ _ n e)
+checkNiceDeclaration' fs c (FunSig _ a _ i _ _ _ _ n e)
   = checkExpr c e >> checkName' False fs (fromAccess a) RangeDefinition n
+  >>= \c' -> markInstance i n >> pure c'
 checkNiceDeclaration' _ c (FunDef _ _ _ _ _ _ _ cs)
   = checkClauses c cs >> pure mempty
 checkNiceDeclaration' fs c (NiceDataDef _ _ _ _ _ n bs cs)
@@ -2305,6 +2307,19 @@ inFile
   -> Bool
 inFile p (r, _)
   = rangePath r == Just p
+
+-- | Mark an instance declaration as used.  Determining which instances
+-- are selected requires type-checking, which agda-unused does not perform.
+markInstance
+  :: MonadReader Environment m
+  => MonadState State m
+  => IsInstance
+  -> N.Name
+  -> m ()
+markInstance (InstanceDef _) n
+  = modifyDelete (Set.singleton (nameRange n))
+markInstance NotInstanceDef _
+  = pure ()
 
 showTCErr :: TCErr -> String
 showTCErr (TypeError _ _ cl)

--- a/src/Agda/Unused/Check.hs
+++ b/src/Agda/Unused/Check.hs
@@ -1348,6 +1348,9 @@ checkNiceDeclaration' fs c (NiceRecSig _ _ a _ _ _ n bs e)
   = checkNiceSig fs c a RangeRecord n bs e
 checkNiceDeclaration' fs c (NiceDataSig _ _ a _ _ _ n bs e)
   = checkNiceSig fs c a RangeData n bs e
+checkNiceDeclaration' _ c (NiceFunClause _ _ _ _ _ _
+    (Concrete.FunClause l r w _))
+  = fst <$> checkFunClause c l r w
 checkNiceDeclaration' _ _ (NiceFunClause r _ _ _ _ _ _)
   = throwError (ErrorInternal (ErrorUnexpected UnexpectedNiceFunClause r))
 checkNiceDeclaration' fs c (FunSig _ a _ _ _ _ _ _ n e)

--- a/src/Agda/Unused/Check.hs
+++ b/src/Agda/Unused/Check.hs
@@ -856,19 +856,22 @@ checkRawApp c es
   = touchNames c (accessContextMatch (exprNames es) c)
   >> checkExprs c es
 
-exprName
+-- | Extract all identifier parts from an expression.
+-- This includes parts of operator names (e.g., @+_@ contributes @"+"@),
+-- which is needed for matching operator sections.
+exprNameParts
   :: Expr
-  -> Maybe String
-exprName (Ident (N.QName (N.Name _ _ (Id n :| []))))
-  = Just n
-exprName _
-  = Nothing
+  -> [String]
+exprNameParts (Ident (N.QName n))
+  = maybe [] nameIds (fromName n)
+exprNameParts _
+  = []
 
 exprNames
   :: [Expr]
   -> [String]
 exprNames
-  = catMaybes . fmap exprName
+  = concatMap exprNameParts
 
 -- ## Assignments
 

--- a/src/Agda/Unused/Check.hs
+++ b/src/Agda/Unused/Check.hs
@@ -1735,11 +1735,15 @@ checkNiceModuleMacro
   -> ImportDirective
   -> m AccessContext
 checkNiceModuleMacro c a _ a' (SectionApp r bs n es) o i
-  = checkSectionApp c a r a' bs n es o i
-checkNiceModuleMacro _ _ r _ (RecordModuleInstance _ _) _ _
-  = throwError (ErrorUnsupported UnsupportedMacro r)
+  = checkTypedBindings True c bs
+  >>= \c'' -> checkExprs (c <> c'') es
+  >> checkModuleApp c a r a' n o i
+checkNiceModuleMacro c a _ a' (RecordModuleInstance r n) o i
+  = checkModuleApp c a r a' n o i
 
-checkSectionApp
+-- | Look up a module by name, mark it used, check the import directive,
+-- optionally register the module name, and optionally open it.
+checkModuleApp
   :: MonadError Error m
   => MonadReader Environment m
   => MonadState State m
@@ -1748,38 +1752,23 @@ checkSectionApp
   -> Access
   -> Range
   -> N.Name
-  -> [TypedBinding]
   -> N.QName
-  -> [Expr]
   -> OpenShortHand
   -> ImportDirective
   -> m AccessContext
-checkSectionApp c _ r (N.NoName _ _) [] n es DoOpen i
+checkModuleApp c a r a' n o i
   = liftMaybe (ErrorInternal (ErrorName (getRange n))) (fromQName n)
   >>= \n' -> liftLookup r n' (accessContextLookupModule n' c)
   >>= \(C.Module rs c') -> modifyDelete rs
-  >> checkExprs c es
-  >> checkImportDirective Open r n' c' i
-  >>= pure . fromContext (importDirectiveAccess i)
-checkSectionApp c a r a' bs n es DontOpen i
-  = liftMaybe (ErrorInternal (ErrorName (getRange n))) (fromQName n)
-  >>= \n' -> liftMaybe (ErrorInternal (ErrorName (getRange a'))) (fromName a')
-  >>= \a'' -> liftLookup r n' (accessContextLookupModule n' c)
-  >>= \(C.Module rs c') -> modifyDelete rs
-  >> checkTypedBindings True c bs
-  >>= \c'' -> checkExprs (c <> c'') es
-  >> checkImportDirective Module r (QName a'') c' i
-  >>= \c''' -> checkModuleName c''' a r a''
-checkSectionApp c a r a' bs n es DoOpen i
-  = liftMaybe (ErrorInternal (ErrorName (getRange n))) (fromQName n)
-  >>= \n' -> liftMaybe (ErrorInternal (ErrorName (getRange a'))) (fromName a')
-  >>= \a'' -> liftLookup r n' (accessContextLookupModule n' c)
-  >>= \(C.Module rs c') -> modifyDelete rs
-  >> checkTypedBindings True c bs
-  >>= \c'' -> checkExprs (c <> c'') es
-  >> checkImportDirective Module r (QName a'') c' i
-  >>= \c''' -> checkModuleName c''' a r a''
-  >>= \c'''' -> pure (c'''' <> fromContext (importDirectiveAccess i) c''')
+  >> case a' of
+    N.NoName _ _ -> checkImportDirective Open r n' c' i
+      >>= pure . fromContext (importDirectiveAccess i)
+    _ -> liftMaybe (ErrorInternal (ErrorName (getRange a'))) (fromName a')
+      >>= \a'' -> checkImportDirective Module r (QName a'') c' i
+      >>= \c''' -> checkModuleName c''' a r a''
+      >>= \c'''' -> case o of
+        DontOpen -> pure c''''
+        DoOpen -> pure (c'''' <> fromContext (importDirectiveAccess i) c''')
 
 -- ## Imports
 

--- a/src/Agda/Unused/Monad/Error.hs
+++ b/src/Agda/Unused/Monad/Error.hs
@@ -136,11 +136,6 @@ data InternalError where
     :: !Range
     -> InternalError
 
-  -- | Unexpected empty top level module name.
-  ErrorModuleName
-    :: !FilePath
-    -> InternalError
-
   -- | Unexpected underscore as name.
   ErrorName
     :: !Range

--- a/src/Agda/Unused/Monad/Error.hs
+++ b/src/Agda/Unused/Monad/Error.hs
@@ -37,6 +37,8 @@ import Agda.Syntax.Position
   (Range, getRange)
 import Control.Monad.Except
   (MonadError, throwError)
+import Data.List.NonEmpty
+  (NonEmpty(..))
 
 -- ## Definitions
 
@@ -133,11 +135,6 @@ data InternalError where
     :: !Range
     -> InternalError
 
-  -- | Unexpected arguments to SectionApp constructor.
-  ErrorMacro
-    :: !Range
-    -> InternalError
-
   -- | Unexpected empty top level module name.
   ErrorModuleName
     :: !FilePath
@@ -209,19 +206,21 @@ data UnsupportedError where
   UnsupportedUnquote
     :: UnsupportedError
 
+  -- | Left-hand side let (using p <- e).
+  UnsupportedLeftLet
+    :: UnsupportedError
+
   deriving Show
 
 -- ## Fixity
 
 instance (Monad m, MonadError Error m) => MonadFixityError m where
-  throwMultipleFixityDecls []
-    = throwError (ErrorFixity Nothing)
-  throwMultipleFixityDecls ((n, _) : _)
+  throwMultipleFixityDecls ((n, _) :| _)
     = throwError (ErrorFixity (Just (getRange n)))
-  throwMultiplePolarityPragmas []
-    = throwError (ErrorPolarity Nothing)
-  throwMultiplePolarityPragmas (n : _)
+  throwMultiplePolarityPragmas (n :| _)
     = throwError (ErrorPolarity (Just (getRange n)))
+  warnEmptyPolarityPragma _
+    = pure ()
   warnUnknownNamesInFixityDecl _
     = pure ()
   warnUnknownNamesInPolarityPragmas _

--- a/src/Agda/Unused/Monad/Error.hs
+++ b/src/Agda/Unused/Monad/Error.hs
@@ -207,10 +207,6 @@ data UnsupportedError where
   UnsupportedUnquote
     :: UnsupportedError
 
-  -- | Left-hand side let (using p <- e).
-  UnsupportedLeftLet
-    :: UnsupportedError
-
   deriving Show
 
 -- ## Fixity

--- a/src/Agda/Unused/Monad/Error.hs
+++ b/src/Agda/Unused/Monad/Error.hs
@@ -199,10 +199,6 @@ data UnsupportedError where
   UnsupportedLoneConstructor
     :: UnsupportedError
 
-  -- | Record module instance applications.
-  UnsupportedMacro
-    :: UnsupportedError
-
   -- | Unquoting primitives.
   UnsupportedUnquote
     :: UnsupportedError

--- a/src/Agda/Unused/Monad/Error.hs
+++ b/src/Agda/Unused/Monad/Error.hs
@@ -86,7 +86,8 @@ data Error where
 
   -- | Error in computing include paths.
   ErrorInclude
-    :: Error
+    :: !String
+    -> Error
 
   -- | Internal error; should be reported.
   ErrorInternal

--- a/src/Agda/Unused/Monad/Reader.hs
+++ b/src/Agda/Unused/Monad/Reader.hs
@@ -17,14 +17,18 @@ module Agda.Unused.Monad.Reader
   , askGlobalMain
   , askRoot
   , askIncludes
+  , askSuppressions
 
     -- * Local
 
   , localSkip
   , localGlobal
+  , localSuppressions
 
   ) where
 
+import Agda.Unused.Suppress
+  (SuppressionMap)
 import Agda.Utils.FileName
   (AbsolutePath)
 import Control.Monad.Reader
@@ -67,7 +71,10 @@ data Environment
   , environmentIncludes
     :: !(NonEmpty AbsolutePath)
     -- ^ The include paths.
-  } deriving Show
+  , environmentSuppressions
+    :: !SuppressionMap
+    -- ^ Suppression markers for the current file.
+  }
 
 -- ## Ask
 
@@ -137,4 +144,20 @@ localGlobal
   -> m a
 localGlobal
   = localMode Global
+
+-- | Ask for the current suppression map.
+askSuppressions
+  :: MonadReader Environment m
+  => m SuppressionMap
+askSuppressions
+  = environmentSuppressions <$> ask
+
+-- | Perform a local computation with a different suppression map.
+localSuppressions
+  :: MonadReader Environment m
+  => SuppressionMap
+  -> m a
+  -> m a
+localSuppressions sm
+  = local (\e -> e {environmentSuppressions = sm})
 

--- a/src/Agda/Unused/Monad/Reader.hs
+++ b/src/Agda/Unused/Monad/Reader.hs
@@ -29,6 +29,8 @@ import Agda.Utils.FileName
   (AbsolutePath)
 import Control.Monad.Reader
   (MonadReader, ask, local)
+import Data.List.NonEmpty
+  (NonEmpty)
 
 -- ## Definition
 
@@ -63,7 +65,7 @@ data Environment
     :: !FilePath
     -- ^ The project root path.
   , environmentIncludes
-    :: ![AbsolutePath]
+    :: !(NonEmpty AbsolutePath)
     -- ^ The include paths.
   } deriving Show
 
@@ -106,7 +108,7 @@ askRoot
 -- | Ask for the include paths.
 askIncludes
   :: MonadReader Environment m
-  => m [AbsolutePath]
+  => m (NonEmpty AbsolutePath)
 askIncludes
   = environmentIncludes <$> ask
 

--- a/src/Agda/Unused/Monad/State.hs
+++ b/src/Agda/Unused/Monad/State.hs
@@ -33,7 +33,9 @@ module Agda.Unused.Monad.State
   ) where
 
 import Agda.Unused.Monad.Reader
-  (Environment, askSkip)
+  (Environment, askSkip, askSuppressions)
+import Agda.Unused.Suppress
+  (isSuppressed)
 import Agda.Unused.Types.Context
   (Context)
 import Agda.Unused.Types.Name
@@ -235,8 +237,11 @@ modifyInsert
   => Range
   -> RangeInfo
   -> m ()
-modifyInsert r i
-  = askSkip >>= flip unless (modify (stateInsert r i))
+modifyInsert r i = do
+  skip <- askSkip
+  sm <- askSuppressions
+  unless (skip || isSuppressed sm r i) $
+    modify (stateInsert r i)
 
 -- | Mark a list of items as used.
 modifyDelete

--- a/src/Agda/Unused/Monad/State.hs
+++ b/src/Agda/Unused/Monad/State.hs
@@ -46,7 +46,13 @@ import Agda.Syntax.Common
 import Agda.Syntax.Position
   (Range, Range'(..))
 import Agda.TypeChecking.Monad.Base
-  (ModuleToSource)
+  (ModuleToSource(..), FileDictWithBuiltins(..))
+import Agda.Utils.FileId
+  (FileDictBuilder)
+import Agda.Utils.FileName
+  (AbsolutePath)
+import Agda.Utils.Null
+  (empty)
 import Control.Monad
   (unless)
 import Control.Monad.Reader
@@ -94,15 +100,18 @@ data State
   , stateHash
     :: !Word64
     -- ^ An integer to use as the next module hash.
-  } deriving Show
+  }
 
 -- ## Interface
 
--- | Construct an empty state.
+-- | Construct an empty state given the primitive library directory.
 stateEmpty
-  :: State
-stateEmpty
-  = State mempty mempty mempty 0
+  :: AbsolutePath
+  -> State
+stateEmpty primLibDir
+  = State mempty mempty
+      (ModuleToSource (FileDictWithBuiltins (empty :: FileDictBuilder) empty primLibDir) Map.empty)
+      0
 
 -- | Get a sorted list of state items.
 --

--- a/src/Agda/Unused/Print.hs
+++ b/src/Agda/Unused/Print.hs
@@ -8,6 +8,8 @@ module Agda.Unused.Print
   , printUnused
   , printUnusedItems
   , printNothing
+  , relativizeUnused
+  , relativizeUnusedItems
   ) where
 
 import Agda.Unused
@@ -24,15 +26,21 @@ import Agda.Interaction.FindFile
 import Agda.Syntax.Concrete.Definitions.Errors
   (DeclarationException(..))
 import Agda.Syntax.Position
-  (Range, Range'(..), getRange)
+  (Range, Range'(..), RangeFile(..), getRange)
 import Agda.Syntax.Common.Pretty
   (prettyShow)
+import Agda.Utils.FileName
+  (AbsolutePath(..), filePath)
+import qualified Agda.Utils.Maybe.Strict
+  as S
 import Data.Semigroup
   (sconcat)
 import Data.Text
   (Text)
 import qualified Data.Text
   as T
+import System.FilePath
+  (makeRelative, normalise)
 
 -- ## Utilities
 
@@ -47,12 +55,6 @@ parens
   -> Text
 parens t
   = "(" <> t <> ")"
-
-indent
-  :: Text
-  -> Text
-indent t
-  = "  " <> t
 
 -- ## Names
 
@@ -78,6 +80,34 @@ printQName (Qual n ns)
 
 -- ## Ranges
 
+-- | Rewrite absolute paths in a range to be relative to the given base
+-- directory. HACK: stuffs a relative path into AbsolutePath so that
+-- prettyShow prints short paths.
+relativizeRange
+  :: FilePath
+  -> Range
+  -> Range
+relativizeRange base (Range (S.Just (RangeFile p m)) is)
+  = Range (S.Just (RangeFile (AbsolutePath (T.pack (makeRelative (normalise base) (filePath p)))) m)) is
+relativizeRange _ r
+  = r
+
+-- | Make paths in unused items relative to the given base directory.
+relativizeUnusedItems
+  :: FilePath
+  -> UnusedItems
+  -> UnusedItems
+relativizeUnusedItems base (UnusedItems items)
+  = UnusedItems (map (\(r, i) -> (relativizeRange base r, i)) items)
+
+-- | Make paths in unused results relative to the given base directory.
+relativizeUnused
+  :: FilePath
+  -> Unused
+  -> Unused
+relativizeUnused base (Unused files items)
+  = Unused files (relativizeUnusedItems base items)
+
 printRange
   :: Range
   -> Text
@@ -94,13 +124,6 @@ printMessage
   -> Text
 printMessage t1 t2
   = T.intercalate "\n" [t1, t2]
-
-printMessageIndent
-  :: Text
-  -> Text
-  -> Text
-printMessageIndent t1 t2
-  = T.intercalate "\n" [t1, indent t2]
 
 -- ## Errors
 
@@ -146,8 +169,8 @@ printError (ErrorFile p)
   = printErrorFile p
 printError (ErrorFixity Nothing)
   = "Error: Multiple fixity declarations."
-printError ErrorInclude
-  = "Error: Invalid path-related options."
+printError (ErrorInclude msg)
+  = "Error: Invalid path-related options.\n" <> T.pack msg
 printError (ErrorInternal e)
   = printInternalError e
 printError (ErrorParse e)
@@ -241,7 +264,7 @@ printUnusedWith (Just t1) Nothing
   = Just t1
 printUnusedWith (Just t1) (Just t2)
   = Just (T.intercalate "\n" [t1, t2])
-    
+
 printUnusedFiles
   :: [FilePath]
   -> Maybe Text
@@ -254,7 +277,7 @@ printUnusedFile
   :: FilePath
   -> Text
 printUnusedFile p
-  = printMessageIndent (T.pack p) "unused file"
+  = T.pack p <> ": unused file"
 
 -- | Print a collection of unused items.
 printUnusedItems
@@ -276,7 +299,7 @@ printRangeInfoWith
   -> RangeInfo
   -> Text
 printRangeInfoWith r i
-  = printMessageIndent (printRange r) (printRangeInfo i)
+  = printRange r <> ": " <> printRangeInfo i
 
 printRangeInfo
   :: RangeInfo
@@ -315,4 +338,3 @@ printRangeType RangeRecordConstructor
   = "record constructor"
 printRangeType RangeVariable
   = "variable"
-

--- a/src/Agda/Unused/Print.hs
+++ b/src/Agda/Unused/Print.hs
@@ -193,9 +193,6 @@ printInternalError (ErrorConstructor r)
 printInternalError (ErrorLet r)
   = printMessage (printRange r)
   $ "Internal error: Invalid let statement."
-printInternalError (ErrorModuleName n)
-  = printMessage (T.pack n)
-  $ "Internal error: Empty top-level module name."
 printInternalError (ErrorName r)
   = printMessage (printRange r)
   $ "Internal error: Invalid name."

--- a/src/Agda/Unused/Print.hs
+++ b/src/Agda/Unused/Print.hs
@@ -238,8 +238,6 @@ printUnsupportedError UnsupportedMacro
   = "Record module instance applications"
 printUnsupportedError UnsupportedUnquote
   = "Unquoting primitives"
-printUnsupportedError UnsupportedLeftLet
-  = "Left-hand side let (using)"
 
 -- ## Unused
 

--- a/src/Agda/Unused/Print.hs
+++ b/src/Agda/Unused/Print.hs
@@ -25,7 +25,7 @@ import Agda.Syntax.Concrete.Definitions.Errors
   (DeclarationException(..))
 import Agda.Syntax.Position
   (Range, Range'(..), getRange)
-import Agda.Utils.Pretty
+import Agda.Syntax.Common.Pretty
   (prettyShow)
 import Data.Semigroup
   (sconcat)
@@ -170,9 +170,6 @@ printInternalError (ErrorConstructor r)
 printInternalError (ErrorLet r)
   = printMessage (printRange r)
   $ "Internal error: Invalid let statement."
-printInternalError (ErrorMacro r)
-  = printMessage (printRange r)
-  $ "Internal error: Invalid module application."
 printInternalError (ErrorModuleName n)
   = printMessage (T.pack n)
   $ "Internal error: Empty top-level module name."
@@ -218,6 +215,8 @@ printUnsupportedError UnsupportedMacro
   = "Record module instance applications"
 printUnsupportedError UnsupportedUnquote
   = "Unquoting primitives"
+printUnsupportedError UnsupportedLeftLet
+  = "Left-hand side let (using)"
 
 -- ## Unused
 

--- a/src/Agda/Unused/Print.hs
+++ b/src/Agda/Unused/Print.hs
@@ -234,8 +234,6 @@ printUnsupportedError
   -> Text
 printUnsupportedError UnsupportedLoneConstructor
   = "Lone constructors"
-printUnsupportedError UnsupportedMacro
-  = "Record module instance applications"
 printUnsupportedError UnsupportedUnquote
   = "Unquoting primitives"
 

--- a/src/Agda/Unused/Suppress.hs
+++ b/src/Agda/Unused/Suppress.hs
@@ -1,0 +1,91 @@
+{- |
+Module: Agda.Unused.Suppress
+
+Filter unused items that have been suppressed with an inline comment.
+
+Supported markers (as the start of a comment's content, after trimming):
+
+* @-- agda-unused: ignore@     — suppress all reports on that line
+* @-- agda-unused: instances@  — suppress only whole-import reports
+                                  (useful for imports kept solely for instances)
+-}
+module Agda.Unused.Suppress
+  ( Suppression(..)
+  , SuppressionMap
+  , extractSuppressions
+  , isSuppressed
+  ) where
+
+import Agda.Unused.Types.Range
+  (RangeInfo(..), RangeType(..))
+
+import Agda.Syntax.Parser.Tokens
+  (Token(..))
+import Agda.Syntax.Position
+  (Interval'(iStart'), Range, Range'(..), RangeFile(..), posLine, rStart')
+import Agda.Utils.FileName
+  (filePath)
+import qualified Agda.Utils.Maybe.Strict
+  as S
+
+import Data.IntMap.Strict (IntMap)
+import qualified Data.IntMap.Strict as IntMap
+import Data.List (isPrefixOf)
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import Data.Word (Word32)
+
+-- | The kind of suppression on a given line.
+data Suppression
+  = SuppressAll
+  -- ^ Suppress all reports on this line.
+  | SuppressImport
+  -- ^ Suppress only whole-import reports on this line.
+  deriving (Show, Eq)
+
+-- | Map from file path to line-number-indexed suppressions.
+type SuppressionMap = Map FilePath (IntMap Suppression)
+
+-- | Extract suppression markers from a token stream for a given file.
+extractSuppressions :: FilePath -> [Token] -> SuppressionMap
+extractSuppressions fp tokens =
+  case IntMap.fromList (concatMap commentSuppression tokens) of
+    m | IntMap.null m -> Map.empty
+      | otherwise     -> Map.singleton fp m
+  where
+    commentSuppression :: Token -> [(Int, Suppression)]
+    commentSuppression (TokComment (iv, str)) =
+      case parseSuppression str of
+        Just s  -> [(fromIntegral (posLine (iStart' iv)), s)]
+        Nothing -> []
+    commentSuppression _ = []
+
+    -- | Parse a suppression marker from a comment string (includes @--@).
+    parseSuppression :: String -> Maybe Suppression
+    parseSuppression s = case dropWhile (== ' ') (drop 2 s) of
+      s' | isPrefixOf "agda-unused: ignore" s'    -> Just SuppressAll
+         | isPrefixOf "agda-unused: instances" s' -> Just SuppressImport
+         | otherwise                              -> Nothing
+
+-- | Check whether a single item is suppressed.
+isSuppressed :: SuppressionMap -> Range -> RangeInfo -> Bool
+isSuppressed sm r ri = case rangeFileLine r of
+  Nothing -> False
+  Just (fp, line) -> case Map.lookup fp sm of
+    Nothing -> False
+    Just lm -> case IntMap.lookup (fromIntegral line) lm of
+      Nothing             -> False
+      Just SuppressAll    -> True
+      Just SuppressImport -> isImport ri
+  where
+    isImport :: RangeInfo -> Bool
+    isImport (RangeNamed RangeImport _) = True
+    isImport _ = False
+
+    rangeFileLine :: Range -> Maybe (FilePath, Word32)
+    rangeFileLine r' = case r' of
+      Range (S.Just (RangeFile p _)) _ ->
+        case rStart' r' of
+          Just pos -> Just (filePath p, posLine pos)
+          Nothing  -> Nothing
+      _ -> Nothing

--- a/src/Agda/Unused/Types/Access.hs
+++ b/src/Agda/Unused/Types/Access.hs
@@ -54,7 +54,7 @@ access _ y Public
 fromAccess
   :: C.Access
   -> Access
-fromAccess (C.PrivateAccess _)
+fromAccess (C.PrivateAccess _ _)
   = Private
 fromAccess C.PublicAccess
   = Public

--- a/src/Agda/Unused/Types/Name.hs
+++ b/src/Agda/Unused/Types/Name.hs
@@ -180,7 +180,7 @@ fromAsName (AsName (Right n) _)
 fromModuleName
   :: RawTopLevelModuleName
   -> QName
-fromModuleName (RawTopLevelModuleName _ (n :| ns))
+fromModuleName (RawTopLevelModuleName _ (n :| ns) _)
   = fromTexts n ns
 
 fromTexts

--- a/src/Agda/Unused/Types/Range.hs
+++ b/src/Agda/Unused/Types/Range.hs
@@ -10,6 +10,12 @@ module Agda.Unused.Types.Range
     RangeType(..)
   , RangeInfo(..)
 
+    -- * Labels
+
+  , rangeTypeLabel
+  , parseRangeType
+  , allRangeTypes
+
     -- * Interface
 
   , rangePath
@@ -71,7 +77,7 @@ data RangeType where
   RangeVariable
     :: RangeType
 
-  deriving (Eq, Ord, Show)
+  deriving (Bounded, Enum, Eq, Ord, Show)
 
 -- | Information associated with an item found at a certain range.
 data RangeInfo where
@@ -85,6 +91,45 @@ data RangeInfo where
     :: RangeInfo
 
   deriving (Eq, Ord, Show)
+
+-- ## Labels
+
+-- | User-facing label for a 'RangeType'.
+rangeTypeLabel :: RangeType -> String
+rangeTypeLabel RangeData = "data"
+rangeTypeLabel RangeDefinition = "definitions"
+rangeTypeLabel RangeImport = "imports"
+rangeTypeLabel RangeImportItem = "import-items"
+rangeTypeLabel RangeModule = "modules"
+rangeTypeLabel RangeModuleItem = "module-items"
+rangeTypeLabel RangeOpen = "opens"
+rangeTypeLabel RangeOpenItem = "open-items"
+rangeTypeLabel RangePatternSynonym = "pattern-synonyms"
+rangeTypeLabel RangePostulate = "postulates"
+rangeTypeLabel RangeRecord = "records"
+rangeTypeLabel RangeRecordConstructor = "record-constructors"
+rangeTypeLabel RangeVariable = "variables"
+
+-- | Parse a label string into a 'RangeType'.
+parseRangeType :: String -> Maybe RangeType
+parseRangeType "data" = Just RangeData
+parseRangeType "definitions" = Just RangeDefinition
+parseRangeType "imports" = Just RangeImport
+parseRangeType "import-items" = Just RangeImportItem
+parseRangeType "modules" = Just RangeModule
+parseRangeType "module-items" = Just RangeModuleItem
+parseRangeType "opens" = Just RangeOpen
+parseRangeType "open-items" = Just RangeOpenItem
+parseRangeType "pattern-synonyms" = Just RangePatternSynonym
+parseRangeType "postulates" = Just RangePostulate
+parseRangeType "records" = Just RangeRecord
+parseRangeType "record-constructors" = Just RangeRecordConstructor
+parseRangeType "variables" = Just RangeVariable
+parseRangeType _ = Nothing
+
+-- | All 'RangeType' values.
+allRangeTypes :: [RangeType]
+allRangeTypes = [minBound .. maxBound]
 
 -- ## Interface
 

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -240,13 +240,10 @@ testUnusedExample (Right is)
 testUnusedOutput
   :: Maybe [Text]
   -> Expectation
-testUnusedOutput (Just [t0, t1, t2, t3, t4, t5])
-  = (t0 `shouldSatisfy` T.isSuffixOf "/Test.agda:4.23-27")
-  >> (t1 `shouldBe` "  unused imported item ‘true’")
-  >> (t2 `shouldSatisfy` T.isSuffixOf "/Test.agda:5.1-30")
-  >> (t3 `shouldBe` "  unused import ‘Agda.Builtin.Unit’")
-  >> (t4 `shouldSatisfy` T.isSuffixOf "/Test.agda:11.9-10")
-  >> (t5 `shouldBe` "  unused variable ‘x’")
+testUnusedOutput (Just [t0, t1, t2])
+  = (t0 `shouldSatisfy` T.isSuffixOf "Test.agda:4.23-27: unused imported item ‘true’")
+  >> (t1 `shouldSatisfy` T.isSuffixOf "Test.agda:5.1-30: unused import ‘Agda.Builtin.Unit’")
+  >> (t2 `shouldSatisfy` T.isSuffixOf "Test.agda:11.9-10: unused variable ‘x’")
 testUnusedOutput _
   = expectationFailure ""
 
@@ -857,4 +854,3 @@ testExample
   = describe "example"
   $ it "outputs the text in README.md"
   $ testCheckExample
-

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -599,6 +599,14 @@ testResult t
       ~: Definition
     , public (name "m")
       ~: Definition
+      -- let open (NiceOpen path): p uses plain-val; q's open is unused
+      -- Without the NiceOpen fix, p and q cause "Internal error: Invalid let statement"
+    , public (name "p")
+      ~: Definition
+    , public (name "q")
+      ~: Definition
+    , private (name "Plain")
+      ~: Open
     ]
 
   Expression DoBlock1 ->

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -428,6 +428,9 @@ data IntegrationTest where
   SuppressDefinition
     :: IntegrationTest
 
+  CrossFile
+    :: IntegrationTest
+
   deriving Show
 
 testDir
@@ -537,6 +540,8 @@ testFileName (Integration SuppressImport)
   = "SuppressImport"
 testFileName (Integration SuppressDefinition)
   = "SuppressDefinition"
+testFileName (Integration CrossFile)
+  = "CrossFile"
 
 testResult
   :: Test
@@ -918,6 +923,19 @@ testResult t
       ~: Postulate
     ]
 
+  -- Regression: CrossFileDep's 'true' (bytes 70–74) falls inside
+  -- CrossFile's 'open import Agda.Builtin.Bool' (bytes 45–74).
+  Integration CrossFile ->
+    [ private (name "CrossFileDep")
+      ~: Import
+    , private agdaBuiltinBool
+      ~: Import
+    , private (name "true")
+      ~: ImportItem
+    , public (name "x")
+      ~: Definition
+    ]
+
 -- ## Main
 
 main
@@ -1034,3 +1052,5 @@ testIntegration = describe "integration"
     (testCheck (Integration SuppressImport))
   >> it "checks suppression comments on definitions (SuppressDefinition)"
     (testCheck (Integration SuppressDefinition))
+  >> it "cross-file byte-position overlap does not suppress items (CrossFile)"
+    (testCheck (Integration CrossFile))

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -241,11 +241,11 @@ testUnusedOutput
   :: Maybe [Text]
   -> Expectation
 testUnusedOutput (Just [t0, t1, t2, t3, t4, t5])
-  = (t0 `shouldSatisfy` T.isSuffixOf "/Test.agda:4,23-27")
+  = (t0 `shouldSatisfy` T.isSuffixOf "/Test.agda:4.23-27")
   >> (t1 `shouldBe` "  unused imported item ‘true’")
-  >> (t2 `shouldSatisfy` T.isSuffixOf "/Test.agda:5,1-30")
+  >> (t2 `shouldSatisfy` T.isSuffixOf "/Test.agda:5.1-30")
   >> (t3 `shouldBe` "  unused import ‘Agda.Builtin.Unit’")
-  >> (t4 `shouldSatisfy` T.isSuffixOf "/Test.agda:11,9-10")
+  >> (t4 `shouldSatisfy` T.isSuffixOf "/Test.agda:11.9-10")
   >> (t5 `shouldBe` "  unused variable ‘x’")
 testUnusedOutput _
   = expectationFailure ""

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -390,6 +390,9 @@ data DeclarationTest where
   Module'
     :: DeclarationTest
 
+  OperatorSection
+    :: DeclarationTest
+
   deriving Show
 
 testDir
@@ -477,6 +480,8 @@ testFileName (Declaration ModuleMacro)
   = "ModuleMacro"
 testFileName (Declaration Module')
   = "Module"
+testFileName (Declaration OperatorSection)
+  = "OperatorSection"
 
 testResult
   :: Test
@@ -762,6 +767,11 @@ testResult t
       ~: Definition
     ]
 
+  Declaration OperatorSection ->
+    [ public (name "f")
+      ~: Definition
+    ]
+
 -- ## Main
 
 main
@@ -847,6 +857,8 @@ testDeclaration
     (testCheck (Declaration ModuleMacro))
   >> it "checks module definitions (Module)"
     (testCheck (Declaration Module'))
+  >> it "checks operator sections (OperatorSection)"
+    (testCheck (Declaration OperatorSection))
 
 testExample
   :: Spec

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -402,6 +402,9 @@ data DeclarationTest where
   LetPattern
     :: DeclarationTest
 
+  RecordInstance
+    :: DeclarationTest
+
   deriving Show
 
 testDir
@@ -497,6 +500,8 @@ testFileName (Declaration LeftLet')
   = "LeftLet"
 testFileName (Declaration LetPattern)
   = "LetPattern"
+testFileName (Declaration RecordInstance)
+  = "RecordInstance"
 
 testResult
   :: Test
@@ -808,6 +813,28 @@ testResult t
       ~: Definition
     ]
 
+  -- SectionApp via explicit arg: B unused in anonymous open; M.A used.
+  -- RecordModuleInstance via ⦃ ... ⦄: N.B used; two anonymous opens
+  --   (one entirely unused, one with A' unused but B' used).
+  Declaration RecordInstance ->
+    [ private (name "B")    -- SectionApp open: B not referenced
+      ~: OpenItem
+    , public (name "a")     -- postulate using opened A
+      ~: Postulate
+    , public (name "b")     -- postulate using M.A
+      ~: Postulate
+    , public (name "c")     -- postulate using N.B
+      ~: Postulate
+    , private (name "R")    -- RecordModuleInstance open: entirely unused
+      ~: Open
+    , private (name "A")    -- RecordModuleInstance open: A not referenced
+      ~: OpenItem
+    , private (name "A'")   -- RecordModuleInstance open: A' not referenced (B' used)
+      ~: OpenItem
+    , public (name "d")     -- postulate using opened B'
+      ~: Postulate
+    ]
+
 -- ## Main
 
 main
@@ -901,6 +928,8 @@ testDeclaration
     (testCheck (Declaration LeftLet'))
   >> it "checks let-patterns in type signatures (LetPattern)"
     (testCheck (Declaration LetPattern))
+  >> it "checks record module instances (RecordInstance)"
+    (testCheck (Declaration RecordInstance))
 
 testExample
   :: Spec

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -396,6 +396,9 @@ data DeclarationTest where
   WhereWith
     :: DeclarationTest
 
+  LeftLet'
+    :: DeclarationTest
+
   LetPattern
     :: DeclarationTest
 
@@ -490,6 +493,8 @@ testFileName (Declaration OperatorSection)
   = "OperatorSection"
 testFileName (Declaration WhereWith)
   = "WhereWith"
+testFileName (Declaration LeftLet')
+  = "LeftLet"
 testFileName (Declaration LetPattern)
   = "LetPattern"
 
@@ -789,6 +794,13 @@ testResult t
       ~: Definition
     ]
 
+  Declaration LeftLet' ->
+    [ private (name "b")
+      ~: Variable
+    , public (name "f")
+      ~: Definition
+    ]
+
   Declaration LetPattern ->
     [ private (name "b")
       ~: Variable
@@ -885,6 +897,8 @@ testDeclaration
     (testCheck (Declaration OperatorSection))
   >> it "checks where-open in with-clauses (WhereWith)"
     (testCheck (Declaration WhereWith))
+  >> it "checks left-hand side let (LeftLet)"
+    (testCheck (Declaration LeftLet'))
   >> it "checks let-patterns in type signatures (LetPattern)"
     (testCheck (Declaration LetPattern))
 

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -405,6 +405,12 @@ data DeclarationTest where
   RecordInstance
     :: DeclarationTest
 
+  QualifiedName
+    :: DeclarationTest
+
+  SubModuleOpen
+    :: DeclarationTest
+
   deriving Show
 
 testDir
@@ -502,6 +508,10 @@ testFileName (Declaration LetPattern)
   = "LetPattern"
 testFileName (Declaration RecordInstance)
   = "RecordInstance"
+testFileName (Declaration QualifiedName)
+  = "QualifiedName"
+testFileName (Declaration SubModuleOpen)
+  = "SubModuleOpen"
 
 testResult
   :: Test
@@ -843,6 +853,19 @@ testResult t
       ~: Postulate
     ]
 
+  Declaration QualifiedName ->
+    [ private (name "suc")
+      ~: ImportItem
+    , public (name "f")
+      ~: Definition
+    ]
+
+  -- open import + open of sub-module: import is marked used by sub-module open
+  Declaration SubModuleOpen ->
+    [ public (name "f")
+      ~: Definition
+    ]
+
 -- ## Main
 
 main
@@ -938,6 +961,10 @@ testDeclaration
     (testCheck (Declaration LetPattern))
   >> it "checks record module instances (RecordInstance)"
     (testCheck (Declaration RecordInstance))
+  >> it "checks qualified alias access clears import (QualifiedName)"
+    (testCheck (Declaration QualifiedName))
+  >> it "checks open import with sub-module open (SubModuleOpen)"
+    (testCheck (Declaration SubModuleOpen))
 
 testExample
   :: Spec

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -288,6 +288,10 @@ data Test where
     :: !DeclarationTest
     -> Test
 
+  Integration
+    :: !IntegrationTest
+    -> Test
+
   deriving Show
 
 data PatternTest where
@@ -416,6 +420,16 @@ data DeclarationTest where
 
   deriving Show
 
+data IntegrationTest where
+
+  SuppressImport
+    :: IntegrationTest
+
+  SuppressDefinition
+    :: IntegrationTest
+
+  deriving Show
+
 testDir
   :: Test
   -> FilePath
@@ -424,6 +438,8 @@ testDir (Pattern _)
 testDir (Expression _)
   = "expression"
 testDir (Declaration _)
+  = "declaration"
+testDir (Integration _)
   = "declaration"
 
 testRootPath
@@ -517,6 +533,10 @@ testFileName (Declaration SubModuleOpen)
   = "SubModuleOpen"
 testFileName (Declaration Instance')
   = "Instance"
+testFileName (Integration SuppressImport)
+  = "SuppressImport"
+testFileName (Integration SuppressDefinition)
+  = "SuppressDefinition"
 
 testResult
   :: Test
@@ -878,6 +898,26 @@ testResult t
       ~: Definition
     ]
 
+  Integration SuppressImport ->
+    [ private (name "g")
+      ~: Postulate
+    , private (name "A")
+      ~: ImportItem
+    , public (name "g")
+      ~: Definition
+    , public (name "f")
+      ~: Definition
+    , public (name "h")
+      ~: Definition
+    ]
+
+  Integration SuppressDefinition ->
+    [ private (name "refl")
+      ~: ImportItem
+    , private (name "+0'")
+      ~: Postulate
+    ]
+
 -- ## Main
 
 main
@@ -893,6 +933,7 @@ testAll
   >> testExpression
   >> testDeclaration
   >> testExample
+  >> testIntegration
 
 testPattern
   :: Spec
@@ -986,3 +1027,10 @@ testExample
   = describe "example"
   $ it "outputs the text in README.md"
   $ testCheckExample
+
+testIntegration :: Spec
+testIntegration = describe "integration"
+  $ it "checks suppression comments on imports (SuppressImport)"
+    (testCheck (Integration SuppressImport))
+  >> it "checks suppression comments on definitions (SuppressDefinition)"
+    (testCheck (Integration SuppressDefinition))

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -411,6 +411,9 @@ data DeclarationTest where
   SubModuleOpen
     :: DeclarationTest
 
+  Instance'
+    :: DeclarationTest
+
   deriving Show
 
 testDir
@@ -512,6 +515,8 @@ testFileName (Declaration QualifiedName)
   = "QualifiedName"
 testFileName (Declaration SubModuleOpen)
   = "SubModuleOpen"
+testFileName (Declaration Instance')
+  = "Instance"
 
 testResult
   :: Test
@@ -866,6 +871,13 @@ testResult t
       ~: Definition
     ]
 
+  Declaration Instance' ->
+    [ private (name "g")
+      ~: Postulate
+    , public (name "h")
+      ~: Definition
+    ]
+
 -- ## Main
 
 main
@@ -965,6 +977,8 @@ testDeclaration
     (testCheck (Declaration QualifiedName))
   >> it "checks open import with sub-module open (SubModuleOpen)"
     (testCheck (Declaration SubModuleOpen))
+  >> it "checks instance declarations (Instance)"
+    (testCheck (Declaration Instance'))
 
 testExample
   :: Spec

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -396,6 +396,9 @@ data DeclarationTest where
   WhereWith
     :: DeclarationTest
 
+  LetPattern
+    :: DeclarationTest
+
   deriving Show
 
 testDir
@@ -487,6 +490,8 @@ testFileName (Declaration OperatorSection)
   = "OperatorSection"
 testFileName (Declaration WhereWith)
   = "WhereWith"
+testFileName (Declaration LetPattern)
+  = "LetPattern"
 
 testResult
   :: Test
@@ -784,6 +789,13 @@ testResult t
       ~: Definition
     ]
 
+  Declaration LetPattern ->
+    [ private (name "b")
+      ~: Variable
+    , public (name "f")
+      ~: Definition
+    ]
+
 -- ## Main
 
 main
@@ -873,6 +885,8 @@ testDeclaration
     (testCheck (Declaration OperatorSection))
   >> it "checks where-open in with-clauses (WhereWith)"
     (testCheck (Declaration WhereWith))
+  >> it "checks let-patterns in type signatures (LetPattern)"
+    (testCheck (Declaration LetPattern))
 
 testExample
   :: Spec

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -393,6 +393,9 @@ data DeclarationTest where
   OperatorSection
     :: DeclarationTest
 
+  WhereWith
+    :: DeclarationTest
+
   deriving Show
 
 testDir
@@ -482,6 +485,8 @@ testFileName (Declaration Module')
   = "Module"
 testFileName (Declaration OperatorSection)
   = "OperatorSection"
+testFileName (Declaration WhereWith)
+  = "WhereWith"
 
 testResult
   :: Test
@@ -772,6 +777,13 @@ testResult t
       ~: Definition
     ]
 
+  Declaration WhereWith ->
+    [ public (name "swap")
+      ~: Definition
+    , public (name "g")
+      ~: Definition
+    ]
+
 -- ## Main
 
 main
@@ -859,6 +871,8 @@ testDeclaration
     (testCheck (Declaration Module'))
   >> it "checks operator sections (OperatorSection)"
     (testCheck (Declaration OperatorSection))
+  >> it "checks where-open in with-clauses (WhereWith)"
+    (testCheck (Declaration WhereWith))
 
 testExample
   :: Spec


### PR DESCRIPTION
Hi @msuperdock,

Thank you for writing and sharing agda-unused. It helps me keep my Agda code tidy.

The code in this PR fixes some false positives and a bug I encountered when running agda-unused on a project of mine. While I was at it, I also updated the project to Agda 2.8.*, extended language coverage (including `open` in `let` - issue #2) and improved the interface (config file, category filtering options, shorter relative paths, greppable one-line reports, suppression comments, etc.).

I also have a WIP `--fix` flag on a [separate branch](https://github.com/jabarszcz/agda-unused/tree/autofix) for auto-removing unused imports.

As I notice that the last commit on this project is from 2023, I wanted to check whether you are still interested in working on it, and if so, see if this PR aligns with your vision. I'm happy to continue contributing in the future.

I've used Claude Code liberally to iterate over the code and docs, but I've reviewed the product diligently. I know that this PR has a lot to review; if it helps, I can split it or restructure it however works best for you.